### PR TITLE
Create bug templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report-core-package.md
+++ b/.github/ISSUE_TEMPLATE/bug-report-core-package.md
@@ -1,0 +1,37 @@
+---
+name: Bug report core package
+about: Report a bug in the MDTools core package
+title: "[BUG/core]: Short bug description"
+labels: bug
+assignees: ''
+
+---
+
+**MDTools version**
+[e.g. 0.2.1]
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior, optimally with a minimal working example:
+1. Import this module '...'
+2. Run this function '...'
+3. With this arguments '...'
+4. Get this error '...'
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**System information**
+ - OS: [e.g. Ubuntu]
+ - OS Version: [e.g. 20.04.2 LTS]
+ - OS Type: [32-bit or 64-bit]
+ - RAM: [e.g. 15.4 GiB]
+ - CPU: [e.g. Intel Core i7-10750H CPU @ 2.60GHz x 12]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug-report-general.md
+++ b/.github/ISSUE_TEMPLATE/bug-report-general.md
@@ -1,0 +1,43 @@
+---
+name: Bug report general
+about: Report a general bug (e.g. related to GitHub Actions/Workflows)
+title: "[BUG/gen]: Short bug description"
+labels: bug
+assignees: ''
+
+---
+
+**MDTools version**
+[e.g. 0.2.1]
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**Steps to reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '...'
+3. Scroll down to '...'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. Ubuntu]
+ - OS Version: [e.g. 20.04.2 LTS]
+ - Browser: [e.g. Firefox, Chrome, Safari]
+ - Browser Version: [e.g. 22]
+
+**Smartphone (please complete the following information):**
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS]
+ - OS Version: [e.g. 8.1]
+ - Browser: [e.g. Stock Browser, Safari]
+ - Browser Version: [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/bug-report-scripts.md
+++ b/.github/ISSUE_TEMPLATE/bug-report-scripts.md
@@ -1,0 +1,37 @@
+---
+name: Bug report scripts
+about: Report a bug in a MDTools script
+title: "[BUG/script]: Short bug description"
+labels: bug
+assignees: ''
+
+---
+
+**MDTools version**
+[e.g. 0.2.1]
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior, optimally with a minimal working example:
+1. Use this input '...'
+2. Run this script '...'
+3. With this options '...'
+4. Get this error '...'
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**System information**
+ - OS: [e.g. Ubuntu]
+ - OS Version: [e.g. 20.04.2 LTS]
+ - OS Type: [32-bit or 64-bit]
+ - RAM: [e.g. 15.4 GiB]
+ - CPU: [e.g. Intel Core i7-10750H CPU @ 2.60GHz x 12]
+
+**Additional context**
+Add any other context about the problem here.


### PR DESCRIPTION
Created three templates to report bugs:
  * General bugs that cannot be attributed to the MDTools core package or scripts
  * Bugs in MDTools scripts
  * Bugs in the MDTools core package