### PR TITLE
Fix/docs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,8 +1,9 @@
-# Date: 2021/06/26
 # Requirements to build MDTools' documentation.
-# These requirements apply additional to the install requirements of in
-# the root level of MDTools.
+#
+# These requirements apply additionally to the install requirements of
+# MDTools as listed in the requirements file in the root directory of
+# the project.
 
-sphinx >=4.0, <5.0
+sphinx >=3.0, <5.0
 sphinx-rtd-theme >=0.5, <1.0
 readthedocs-sphinx-search >=0.1, <1.0

--- a/docs/source/_templates/breadcrumbs.html
+++ b/docs/source/_templates/breadcrumbs.html
@@ -1,0 +1,15 @@
+<!--
+Custom template to remove the "Edit on ..." button in the header of doc
+pages hosted by Read the Docs.  See
+https://docs.readthedocs.io/en/stable/guides/remove-edit-buttons.html
+and
+https://github.com/sphinx-doc/sphinx/issues/2386#issuecomment-478403897
+-->
+
+{%- extends "sphinx_rtd_theme/breadcrumbs.html" %}
+
+{% block breadcrumbs_aside %}
+{% if not meta or meta.get('github_url') != 'hide' %}
+{{ super() }}
+{% endif %}
+{% endblock %}

--- a/docs/source/_templates/custom-attribute-template.rst
+++ b/docs/source/_templates/custom-attribute-template.rst
@@ -1,3 +1,5 @@
+:github_url: hide
+
 {{ name | escape | underline}}
 
 .. currentmodule:: {{ module }}

--- a/docs/source/_templates/custom-class-template.rst
+++ b/docs/source/_templates/custom-class-template.rst
@@ -7,6 +7,7 @@
    and
    https://sphinx-autosummary-recursion.readthedocs.io/en/latest/index.html
 
+:github_url: hide
 
 {{ name | escape | underline}}
 
@@ -14,11 +15,11 @@
 
 .. autoclass:: {{ objname }}
     :members:
-    
+
     {% block methods %}
     {% if methods %}
     .. rubric:: {{ _('Methods') }}
-    
+
     .. autosummary::
         :template: custom-method-template.rst
         :nosignatures:
@@ -29,11 +30,11 @@
     {%- endfor %}
     {% endif %}
     {% endblock %}
-    
+
     {% block attributes %}
     {% if attributes %}
     .. rubric:: {{ _('Attributes') }}
-    
+
     .. autosummary::
         :template: custom-attribute-template.rst
         :nosignatures:

--- a/docs/source/_templates/custom-function-template.rst
+++ b/docs/source/_templates/custom-function-template.rst
@@ -1,3 +1,5 @@
+:github_url: hide
+
 {{ name | escape | underline}}
 
 .. currentmodule:: {{ module }}

--- a/docs/source/_templates/custom-method-template.rst
+++ b/docs/source/_templates/custom-method-template.rst
@@ -1,3 +1,5 @@
+:github_url: hide
+
 {{ name | escape | underline}}
 
 .. currentmodule:: {{ module }}

--- a/docs/source/_templates/custom-module-template.rst
+++ b/docs/source/_templates/custom-module-template.rst
@@ -7,15 +7,16 @@
    and
    https://sphinx-autosummary-recursion.readthedocs.io/en/latest/index.html
 
+:github_url: hide
 
 {{ name | escape | underline}}
 
 .. automodule:: {{ fullname }}
-    
+
     {% block attributes %}
     {% if attributes %}
     .. rubric:: {{ _('Module Attributes') }}
-    
+
     .. autosummary::
         :toctree:
         :template: custom-attribute-template.rst
@@ -25,11 +26,11 @@
     {%- endfor %}
     {% endif %}
     {% endblock %}
-    
+
     {% block functions %}
     {% if functions %}
     .. rubric:: {{ _('Functions') }}
-    
+
     .. autosummary::
         :toctree:
         :template: custom-function-template.rst
@@ -39,11 +40,11 @@
     {%- endfor %}
     {% endif %}
     {% endblock %}
-    
+
     {% block classes %}
     {% if classes %}
     .. rubric:: {{ _('Classes') }}
-    
+
     .. autosummary::
         :toctree:
         :template: custom-class-template.rst
@@ -53,11 +54,11 @@
     {%- endfor %}
     {% endif %}
     {% endblock %}
-    
+
     {% block exceptions %}
     {% if exceptions %}
     .. rubric:: {{ _('Exceptions') }}
-    
+
     .. autosummary::
         :toctree:
         :nosignatures:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -290,7 +290,8 @@ html_static_path = ["_static"]
 # string is equivalent to "%b %d, %Y" (or a locale-dependent equivalent)
 # html_last_updated_fmt = ""
 
-# Whether to add permalinks for each heading and description environment
+# Whether to add permalinks for each heading and description
+# environment.
 html_permalinks = True
 
 # If True, add an index to the HTML documents.
@@ -338,7 +339,7 @@ htmlhelp_basename = "mdtoolsdoc"
 epub_theme = "epub"
 
 # The description of the document. The default value is 'unknown'.
-epub_description = "MDTools' Documentation"
+epub_description = "MDTools Documentation"
 
 # An identifier for the document.
 epub_identifier = "https://github.com/andthum/mdtools"
@@ -360,7 +361,7 @@ latex_theme = "manual"
 
 # latex_documents determines how to group the document tree into LaTeX
 # source files.
-_targetname = htmlhelp_basename + ".tex"
+_targetname = "mdtoolsdoc.tex"
 _startdocname = master_doc
 _title = "MDTools Documentation"
 _author = r" \and ".join(author.split(", "))
@@ -396,7 +397,6 @@ latex_show_urls = epub_show_urls
 # usually puts into the generated .tex files.
 latex_elements = {
     "papersize": "a4paper",
-    "pointsize": "12pt",
     "extrapackages": r"\usepackage{unicode-math}",
 }
 
@@ -509,17 +509,19 @@ doctest_test_doctest_blocks = "default"
 # -- Options for intersphinx extension ---------------------------------
 
 # Locations and names of other projects that should be linked to in this
-# documentation.
+# documentation.  Here is a list of commonly used mappings:
+# https://gist.github.com/bskinn/0e164963428d4b51017cebdb6cda5209
 intersphinx_mapping = {
-    "matplotlib": ("https://matplotlib.org", None),
+    "matplotlib": ("https://matplotlib.org/stable/", None),
     "MDAnalysis": ("https://docs.mdanalysis.org/stable/", None),
     "numpy": ("https://numpy.org/doc/stable/", None),
-    "psutil": ("https://psutil.readthedocs.io/en/latest/", None),
-    "python": ("https://docs.python.org/3", None),
-    "scipy": ("https://docs.scipy.org/doc/scipy/reference", None),
+    "psutil": ("https://psutil.readthedocs.io/en/stable/", None),
+    "python": ("https://docs.python.org/3/", None),
+    "scipy": ("https://docs.scipy.org/doc/scipy/", None),
+    "Sphinx": ("https://www.sphinx-doc.org/en/stable/", None),
 }
 
-# The maximum number of days to cache remote inventories (in days).
+# The maximum number of days to cache remote inventories.
 intersphinx_cache_limit = 7
 
 
@@ -575,7 +577,7 @@ napoleon_use_param = False
 # False to use a single :keyword arguments: role for all the keywords.
 napoleon_use_keyword = napoleon_use_param
 
-# True to use the :rtype: role for the return type. False to output the
+# True to use the :rtype: role for the return type.  False to output the
 # return type inline with the description.
 napoleon_use_rtype = False
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -302,11 +302,11 @@ html_split_index = False
 
 # If True, the reStructuredText sources are included in the HTML build
 # as _sources/name.
-html_copy_source = False
+html_copy_source = True
 
 # If True (and html_copy_source is True as well), links to the
 # reStructuredText sources will be added to the sidebar.
-html_show_sourcelink = False
+html_show_sourcelink = True
 
 # If nonempty, an OpenSearch description file will be output, and all
 # pages will contain a <link> tag referring to it.   the value of this

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -102,7 +102,7 @@ extensions = [
 source_suffix = {".rst": "restructuredtext"}
 
 # The document that contains the root toctree directive.
-root_doc = "index"
+master_doc = "index"
 
 # A list of glob-style patterns that should be excluded when looking for
 # source files.  They are matched against the source file names relative
@@ -200,7 +200,7 @@ primary_domain = "py"
 default_role = None
 
 # If your documentation needs a minimal Sphinx version, state it here.
-needs_sphinx = "4.0"
+needs_sphinx = "3.0"
 
 # If true, Sphinx will warn about all references where the target cannot
 # be found.
@@ -360,8 +360,8 @@ latex_theme = "manual"
 
 # latex_documents determines how to group the document tree into LaTeX
 # source files.
-_startdocname = root_doc
 _targetname = htmlhelp_basename + ".tex"
+_startdocname = master_doc
 _title = "MDTools Documentation"
 _author = r" \and ".join(author.split(", "))
 _theme = latex_theme


### PR DESCRIPTION
  * Remove "Edit on GitHub" button on autogenerated doc pages that do not have source file on GitHub.
  * Lower the minimum required Sphinx version from 4.0 to 3.0 again.
  * Some minor changes to `docs/source/conf.py`