### PR TITLE
Fix Read The Docs Python requirements

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -19,7 +19,7 @@ sphinx:
 # Optionally set the version of Python and requirements required to
 # build your docs
 python:
-  version: 3.9
+  version: 3.8
   install:
     - requirements: requirements.txt
     - requirements: docs/requirements.txt


### PR DESCRIPTION
This PR fixes a bug that was introduces in PR #32

Read The Docs does not support Python 3.9, so we have to go back to Python 3.8.
