### PR TITLE
[docs/source/conf.py]: Fix Broken Intersphinx Link

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -517,7 +517,7 @@ intersphinx_mapping = {
     "numpy": ("https://numpy.org/doc/stable/", None),
     "psutil": ("https://psutil.readthedocs.io/en/stable/", None),
     "python": ("https://docs.python.org/3/", None),
-    "scipy": ("https://docs.scipy.org/doc/scipy/", None),
+    "scipy": ("https://scipy.github.io/devdocs/", None),
     "Sphinx": ("https://www.sphinx-doc.org/en/stable/", None),
 }
 


### PR DESCRIPTION
Change Intersphinx link to Scipy from https://docs.scipy.org/doc/scipy/
to https://scipy.github.io/devdocs/

This should fix the following warning on Read The Docs:

WARNING: failed to reach any of the inventories with the following issues:
intersphinx inventory 'https://docs.scipy.org/doc/scipy/objects.inv' not fetchable due to <class 'requests.exceptions.HTTPError'>: 404 Client Error: Not Found for url: https://docs.scipy.org/doc/scipy/objects.inv