### PR TITLE
Feat/structure/center

### DIFF
--- a/docs/source/doc_pages/general_docs/usage.rst
+++ b/docs/source/doc_pages/general_docs/usage.rst
@@ -110,9 +110,10 @@ using the -O option.
 .. note::
 
     Currently, most of the checks are wrapped in ``if debug: do check``
-    conditions (see section below), even if the check is computationally
-    cheap.  However, when writing new code or refactoring old one, we
-    will use assert statements for computationally cheap checks.
+    conditions (see :ref:`debug-mode-label`), even if the check is
+    computationally cheap.  However, when writing new code or
+    refactoring old one, we will use assert statements for
+    computationally cheap checks.
 
 
 .. _debug-mode-label:
@@ -131,8 +132,8 @@ These might help you to identify bad user input, parameter settings or
 bugs.  If you spot a bug, please open a new |issue| on |GitHub|.
 
 
-The scripts directory
----------------------
+The scripts/ directory
+----------------------
 
 You should not move the scripts to other directories, because some
 scripts import functions from other scripts with relative imports.
@@ -145,3 +146,43 @@ at their default location in :file:`path/to/mdtools/scripts/`.
 
 
 .. _assert statements: https://docs.python.org/3/reference/simple_stmts.html#the-assert-statement
+
+
+Differences to the terminology of MDAnalysis
+--------------------------------------------
+
+Because MDTools is build on MDAnalysis, we use basically the same
+terminology as MDAnalysis.  However, some terms are used differently.
+Here is a list of terms whoose meaning is different in MDTools compared
+to MDAnalysis:
+
+.. Use alphabetical order!
+
+
+unwrap
+^^^^^^
+
+**Meaning in MDAnalysis:**
+
+    Move atoms in such a way that chemical bonds are not split across
+    periodic boundaries of the simulation box (see e.g.
+    :meth:`MDAnalysis.core.groups.AtomGroup.unwrap`).
+
+    In MDTools this operation is called "make whole", because you fix
+    molecules that are broken across periodic boundaries.
+
+**Meaning in MDTools:**
+
+    Get the real-space positions of all atoms.  In other words, unfold a
+    wrapped trajectory, where all atoms lie within the primary unit
+    cell, and get the positions of all atoms like they were if they had
+    not been put back into the primary unit cell when they have crossed
+    a periodic boundary.
+
+    Real-space positions are e.g. needed when calculating the MSD.
+
+    Usually, it makes only sense to unwrap a trajectory starting from
+    the very first frame, because the unwrapped trajectory is
+    (re-)constructed by suming up the displacements from frame to frame
+    and adding these displacements to the initial configuration.  See
+    e.g. Bülow et al., J. Chem. Phys., 2020, 153, 021101.

--- a/mdtools/structure.py
+++ b/mdtools/structure.py
@@ -231,8 +231,16 @@ def cog(ag, pbc=False, compound='group', make_whole=False, debug=False):
     --------
     :meth:`MDAnalysis.core.groups.AtomGroup.center_of_geometry` :
         Center of geometry of (compounds of) the group
+    :meth:`MDAnalysis.core.groups.AtomGroup.center_of_mass` :
+        Center of mass of (compounds of) the group
     :meth:`MDAnalysis.core.groups.AtomGroup.center` :
         Weighted center of (compounds of) the group
+    :func:`mdtools.structure.wcenter` :
+        Weighted center of (compounds of) an MDAnalysis
+        :class:`~MDAnalysis.core.groups.AtomGroup`
+    :func:`mdtools.structure.com` :
+        Center of mass of (compounds of) an MDAnalysis
+        :class:`~MDAnalysis.core.groups.AtomGroup`
 
     Notes
     -----
@@ -271,8 +279,8 @@ def cog(ag, pbc=False, compound='group', make_whole=False, debug=False):
     if make_whole:
         mdt.box.wrap(
             ag=ag,
-            compound='atoms',  # Does not trigger an additional
-            center='cog',      # call of mdt.check.masses_new()
+            compound='atoms',  # Does not trigger a call of
+            center='cog',      # mdt.check.masses_new()
             box=None,
             inplace=True,
             debug=debug

--- a/mdtools/structure.py
+++ b/mdtools/structure.py
@@ -64,7 +64,8 @@ def wcenter(
         identical weights for all
         :class:`Atoms <MDAnalysis.core.groups.Atom>` in `ag` and
         therefore this is equivalent to calculating the center of
-        geometry.
+        geometry.  If the weights of a compound sum up to zero, the
+        coordinates of that compound's weighted center will be NaN.
     pbc : bool, optional
         If ``True`` and `compound` is ``'group'``, move all
         :class:`Atoms <MDAnalysis.core.groups.Atom>` in `ag` to the
@@ -117,6 +118,16 @@ def wcenter(
     --------
     :meth:`MDAnalysis.core.groups.AtomGroup.center` :
         Weighted center of (compounds of) the group
+    :meth:`MDAnalysis.core.groups.AtomGroup.center_of_geometry` :
+        Center of geometry of (compounds of) the group
+    :meth:`MDAnalysis.core.groups.AtomGroup.center_of_mass` :
+        Center of mass of (compounds of) the group
+    :func:`mdtools.structure.com` :
+        Center of geometry of (compounds of) an MDAnalysis
+        :class:`~MDAnalysis.core.groups.AtomGroup`
+    :func:`mdtools.structure.com` :
+        Center of mass of (compounds of) an MDAnalysis
+        :class:`~MDAnalysis.core.groups.AtomGroup`
 
     Notes
     -----

--- a/mdtools/structure.py
+++ b/mdtools/structure.py
@@ -48,7 +48,7 @@ def wcenter(
     debug=False
 ):
     """
-    Calculate the weighted center of (compounds of) a MDAnalysis
+    Calculate the weighted center of (compounds of) an MDAnalysis
     :class:`~MDAnalysis.core.groups.AtomGroup`.
 
     Parameters
@@ -122,7 +122,10 @@ def wcenter(
         Center of geometry of (compounds of) the group
     :meth:`MDAnalysis.core.groups.AtomGroup.center_of_mass` :
         Center of mass of (compounds of) the group
-    :func:`mdtools.structure.com` :
+    :func:`mdtools.structure.coc` :
+        Center of charge of (compounds of) an MDAnalysis
+        :class:`~MDAnalysis.core.groups.AtomGroup`
+    :func:`mdtools.structure.cog` :
         Center of geometry of (compounds of) an MDAnalysis
         :class:`~MDAnalysis.core.groups.AtomGroup`
     :func:`mdtools.structure.com` :
@@ -312,7 +315,7 @@ def coc(ag, pbc=False, compound='group', make_whole=False, debug=False):
 def cog(ag, pbc=False, compound='group', make_whole=False, debug=False):
     """
     Calculate the center of geometry (a.k.a centroid) of (compounds of)
-    a MDAnalysis :class:`~MDAnalysis.core.groups.AtomGroup`.
+    an MDAnalysis :class:`~MDAnalysis.core.groups.AtomGroup`.
 
     Parameters
     ----------
@@ -369,14 +372,17 @@ def cog(ag, pbc=False, compound='group', make_whole=False, debug=False):
 
     See Also
     --------
+    :meth:`MDAnalysis.core.groups.AtomGroup.center` :
+        Weighted center of (compounds of) the group
     :meth:`MDAnalysis.core.groups.AtomGroup.center_of_geometry` :
         Center of geometry of (compounds of) the group
     :meth:`MDAnalysis.core.groups.AtomGroup.center_of_mass` :
         Center of mass of (compounds of) the group
-    :meth:`MDAnalysis.core.groups.AtomGroup.center` :
-        Weighted center of (compounds of) the group
     :func:`mdtools.structure.wcenter` :
         Weighted center of (compounds of) an MDAnalysis
+        :class:`~MDAnalysis.core.groups.AtomGroup`
+    :func:`mdtools.structure.coc` :
+        Center of charge of (compounds of) an MDAnalysis
         :class:`~MDAnalysis.core.groups.AtomGroup`
     :func:`mdtools.structure.com` :
         Center of mass of (compounds of) an MDAnalysis
@@ -488,14 +494,17 @@ def com(ag, pbc=False, compound='group', make_whole=False, debug=False):
 
     See Also
     --------
-    :meth:`MDAnalysis.core.groups.AtomGroup.center_of_mass` :
-        Center of mass of (compounds of) the group
-    :meth:`MDAnalysis.core.groups.AtomGroup.center_of_geometry` :
-        Center of geometry of (compounds of) the group
     :meth:`MDAnalysis.core.groups.AtomGroup.center` :
         Weighted center of (compounds of) the group
+    :meth:`MDAnalysis.core.groups.AtomGroup.center_of_geometry` :
+        Center of geometry of (compounds of) the group
+    :meth:`MDAnalysis.core.groups.AtomGroup.center_of_mass` :
+        Center of mass of (compounds of) the group
     :func:`mdtools.structure.wcenter` :
         Weighted center of (compounds of) an MDAnalysis
+        :class:`~MDAnalysis.core.groups.AtomGroup`
+    :func:`mdtools.structure.coc` :
+        Center of charge of (compounds of) an MDAnalysis
         :class:`~MDAnalysis.core.groups.AtomGroup`
     :func:`mdtools.structure.cog` :
         Center of geometry of (compounds of) an MDAnalysis

--- a/mdtools/structure.py
+++ b/mdtools/structure.py
@@ -295,6 +295,9 @@ def wcenter(
         Center of geometry of (compounds of) the group
     :meth:`MDAnalysis.core.groups.AtomGroup.center_of_mass` :
         Center of mass of (compounds of) the group
+    :func:`mdtools.structure.center` :
+        Different types of centers of (compounds of) an MDAnalysis
+        :class:`~MDAnalysis.core.groups.AtomGroup`
     :func:`mdtools.structure.coc` :
         Center of charge of (compounds of) an MDAnalysis
         :class:`~MDAnalysis.core.groups.AtomGroup`
@@ -422,6 +425,9 @@ def coc(ag, pbc=False, compound='group', make_whole=False, debug=False):
         Center of geometry of (compounds of) the group
     :meth:`MDAnalysis.core.groups.AtomGroup.center_of_mass` :
         Center of mass of (compounds of) the group
+    :func:`mdtools.structure.center` :
+        Different types of centers of (compounds of) an MDAnalysis
+        :class:`~MDAnalysis.core.groups.AtomGroup`
     :func:`mdtools.structure.wcenter` :
         Weighted center of (compounds of) an MDAnalysis
         :class:`~MDAnalysis.core.groups.AtomGroup`
@@ -551,6 +557,9 @@ def cog(ag, pbc=False, compound='group', make_whole=False, debug=False):
         Center of geometry of (compounds of) the group
     :meth:`MDAnalysis.core.groups.AtomGroup.center_of_mass` :
         Center of mass of (compounds of) the group
+    :func:`mdtools.structure.center` :
+        Different types of centers of (compounds of) an MDAnalysis
+        :class:`~MDAnalysis.core.groups.AtomGroup`
     :func:`mdtools.structure.wcenter` :
         Weighted center of (compounds of) an MDAnalysis
         :class:`~MDAnalysis.core.groups.AtomGroup`
@@ -673,6 +682,9 @@ def com(ag, pbc=False, compound='group', make_whole=False, debug=False):
         Center of geometry of (compounds of) the group
     :meth:`MDAnalysis.core.groups.AtomGroup.center_of_mass` :
         Center of mass of (compounds of) the group
+    :func:`mdtools.structure.center` :
+        Different types of centers of (compounds of) an MDAnalysis
+        :class:`~MDAnalysis.core.groups.AtomGroup`
     :func:`mdtools.structure.wcenter` :
         Weighted center of (compounds of) an MDAnalysis
         :class:`~MDAnalysis.core.groups.AtomGroup`

--- a/mdtools/structure.py
+++ b/mdtools/structure.py
@@ -39,6 +39,117 @@ import MDAnalysis.lib.distances as mdadist
 import mdtools as mdt
 
 
+def cog(ag, pbc=False, compound='group', make_whole=False, debug=False):
+    """
+    Calculate the center of geometry (a.k.a centroid) of (compounds of)
+    a MDAnalysis :class:`~MDAnalysis.core.groups.AtomGroup`.
+
+    Parameters
+    ----------
+    ag : MDAnalysis.core.groups.AtomGroup
+        The MDAnalysis :class:`~MDAnalysis.core.groups.AtomGroup` for
+        which to calculate the center of geometry.
+    pbc : bool, optional
+        If ``True`` and `compound` is ``'group'``, move all
+        :class:`Atoms <MDAnalysis.core.groups.Atom>` in `ag` to the
+        primary unit cell **before** calculating the center of geometry.
+        If ``True`` and `compound` is not ``'group'``, the center of
+        geometry of each compound will be calculated without moving any
+        :class:`Atoms <MDAnalysis.core.groups.Atom>` to keep the
+        compounds intact (if they were intact before).  Instead, the
+        resulting position vectors will be moved to the primary unit
+        cell **after** calculating the center of geometry.
+    compound : {'group', 'segments', 'residues', 'molecules', \
+        'fragments'}, optional
+        The compounds of `ag` for which to calculate the center of
+        geometry.  If ``'group'``, the center of geometry of all
+        :class:`Atoms <MDAnalysis.core.groups.Atom>` in `ag` will be
+        returned as a single position vector.  Else, the centers of
+        geometry of each :class:`~MDAnalysis.core.groups.Segment`,
+        :class:`~MDAnalysis.core.groups.Residue`, molecule, or
+        :attr:`fragment <MDAnalysis.core.groups.AtomGroup.fragments>`
+        contained in `ag` will be returned as an array of position
+        vectors, i.e. a 2d array.  Refer to the MDAnalysis' user guide
+        for an |explanation_of_these_terms|.  Note that in any case,
+        also if `compound` is e.g. ``'residues'``, only the
+        :class:`Atoms <MDAnalysis.core.groups.Atom>` belonging to `ag`
+        are taken into account, even if the compound might comprise
+        additional :class:`Atoms <MDAnalysis.core.groups.Atom>` that are
+        not contained in `ag`.
+    make_whole : bool, optional
+        If ``True``, compounds whose bonds are broken across the box
+        edges are made whole before calculating the center of geometry.
+        Note that all :class:`Atoms <MDAnalysis.core.groups.Atom>` in
+        `ag` are wrapped back into the primary unit cell before making
+        compounds whole to ensure that the algorithm is working
+        properly.  This means that making compounds whole in an
+        unwrapped trajectory while keeping the trajectory unwrapped is
+        not possible with this option.
+    debug : bool, optional
+        If ``True``, run in debug mode.
+
+    Returns
+    -------
+    center : numpy.ndarray
+        Center of geometry positions of the compounds in `ag`.  If
+        `compound` was set to ``'group'``, the output will be a single
+        position vector of shape ``(3,)``.  Else, the output will be a
+        2d array of shape ``(n, 3)`` where ``n`` is the number of
+        compounds in `ag`.
+
+    See Also
+    --------
+    :meth:`MDAnalysis.core.groups.AtomGroup.center_of_geometry` :
+        Center of geometry of (compounds of) the group
+    :meth:`MDAnalysis.core.groups.AtomGroup.center` :
+        Weighted center of (compounds of) the group
+
+    Notes
+    -----
+    This function uses the
+    :meth:`~MDAnalysis.core.groups.AtomGroup.center_of_geometry` method
+    of the input :class:`~MDAnalysis.core.groups.AtomGroup` to calculate
+    the center of geometry.
+
+    If `make_whole` is ``True``, all
+    :class:`Atoms <MDAnalysis.core.groups.Atom>` in `ag` are wrapped
+    back into the primary unit cell using :func:`mdtools.box.wrap`
+    before calling
+    :meth:`~MDAnalysis.core.groups.AtomGroup.center_of_geometry` with
+    the option `unwrap` set to ``True``.  This is done to make sure that
+    the unwrap algorithm (better called "make whole" algorithm) of
+    :meth:`~MDAnalysis.core.groups.AtomGroup.center_of_geometry` is
+    working properly.  This means that making compounds whole in an
+    unwrapped trajectory while keeping the trajectory unwrapped is not
+    possible with this function.
+
+    .. todo::
+
+        Check if it is really necessary to wrap all
+        :class:`Atoms <MDAnalysis.core.groups.Atom>` back into the
+        primary unit cell before calling
+        :meth:`~MDAnalysis.core.groups.AtomGroup.center_of_geometry`
+        with `unwrap` set to ``True``.  The currently done back-wrapping
+        is a serious problem, because it implies an inplace change of
+        the :class:`~MDAnalysis.core.groups.Atom` coordinates.
+
+        If no wrapping is necessary, we can mark this function as
+        deprecated and instead recommend the direct use of
+        :meth:`~MDAnalysis.core.groups.AtomGroup.center_of_geometry`.
+
+    """
+    if make_whole:
+        mdt.box.wrap(
+            ag=ag,
+            compound='atoms',  # Does not trigger an additional
+            center='cog',      # call of mdt.check.masses_new()
+            box=None,
+            inplace=True,
+            debug=debug
+        )
+    return ag.center_of_geometry(pbc=pbc, compound=compound, unwrap=make_whole)
+
+
 def com(ag, pbc=False, compound='group', make_whole=False, debug=False):
     """
     Calculate the center of mass of (compounds of) a MDAnalysis

--- a/mdtools/structure.py
+++ b/mdtools/structure.py
@@ -282,7 +282,7 @@ def cog(ag, pbc=False, compound='group', make_whole=False, debug=False):
 
 def com(ag, pbc=False, compound='group', make_whole=False, debug=False):
     """
-    Calculate the center of mass of (compounds of) a MDAnalysis
+    Calculate the center of mass of (compounds of) an MDAnalysis
     :class:`~MDAnalysis.core.groups.AtomGroup`.
 
     Parameters
@@ -300,7 +300,8 @@ def com(ag, pbc=False, compound='group', make_whole=False, debug=False):
         compounds intact (if they were intact before).  Instead, the
         resulting position vectors will be moved to the primary unit
         cell **after** calculating the center of mass.
-    compound : {'group', 'segments', 'residues', 'molecules', 'fragments'}, optional
+    compound : {'group', 'segments', 'residues', 'molecules',\
+        'fragments'}, optional
         The compounds of `ag` for which to calculate the center of mass.
         If ``'group'``, the center of mass of all
         :class:`Atoms <MDAnalysis.core.groups.Atom>` in `ag` will be
@@ -311,36 +312,46 @@ def com(ag, pbc=False, compound='group', make_whole=False, debug=False):
         contained in `ag` will be returned as an array of position
         vectors, i.e. a 2d array.  Refer to the MDAnalysis' user guide
         for an |explanation_of_these_terms|.  Note that in any case,
-        even if `compound` is e.g. ``'residues'``, only the
+        also if `compound` is e.g. ``'residues'``, only the
         :class:`Atoms <MDAnalysis.core.groups.Atom>` belonging to `ag`
         are taken into account, even if the compound might comprise
         additional :class:`Atoms <MDAnalysis.core.groups.Atom>` that are
         not contained in `ag`.
     make_whole : bool, optional
-        If ``True``, first all
-        :class:`Atoms <MDAnalysis.core.groups.Atom>` in `ag` are wrapped
-        back into the primary unit cell, to make sure that the algorithm
-        is working properly.  Then compounds whose bonds are broken
-        across the box edges are made whole again.  This means that
-        making compounds whole in an unwrapped trajectory while keeping
-        the trajectory unwrapped is not possible with this function.
+        If ``True``, compounds whose bonds are broken across the box
+        edges are made whole before calculating the center of mass.
+        Note that all :class:`Atoms <MDAnalysis.core.groups.Atom>` in
+        `ag` are wrapped back into the primary unit cell before making
+        compounds whole to ensure that the algorithm is working
+        properly.  This means that making compounds whole in an
+        unwrapped trajectory while keeping the trajectory unwrapped is
+        not possible with this option.
     debug : bool, optional
         If ``True``, run in debug mode.
 
     Returns
     -------
     center : numpy.ndarray
-        Center of mass positions of the compounds in `ag`.  If `compound`
-        was set to ``'group'``, the output will be a single position
-        vector.  Else, the output will be a 2d array of shape ``(n, 3)``
-        where ``n`` is the number of compounds in `ag`.
+        Center of mass positions of the compounds in `ag`.  If
+        `compound` was set to ``'group'``, the output will be a single
+        position vector of shape ``(3,)``.  Else, the output will be a
+        2d array of shape ``(n, 3)`` where ``n`` is the number of
+        compounds in `ag`.
 
     See Also
     --------
     :meth:`MDAnalysis.core.groups.AtomGroup.center_of_mass` :
         Center of mass of (compounds of) the group
+    :meth:`MDAnalysis.core.groups.AtomGroup.center_of_geometry` :
+        Center of geometry of (compounds of) the group
     :meth:`MDAnalysis.core.groups.AtomGroup.center` :
         Weighted center of (compounds of) the group
+    :func:`mdtools.structure.wcenter` :
+        Weighted center of (compounds of) an MDAnalysis
+        :class:`~MDAnalysis.core.groups.AtomGroup`
+    :func:`mdtools.structure.cog` :
+        Center of geometry of (compounds of) an MDAnalysis
+        :class:`~MDAnalysis.core.groups.AtomGroup`
 
     Notes
     -----
@@ -371,9 +382,11 @@ def com(ag, pbc=False, compound='group', make_whole=False, debug=False):
         serious problem, because it implies an inplace change of the
         :class:`~MDAnalysis.core.groups.Atom` coordinates.
 
-        If the no wrapping is necessary, we can mark this function as
+        If no wrapping is necessary, we can mark this function as
         deprecated and instead recommend the direct use of
         :meth:`~MDAnalysis.core.groups.AtomGroup.center_of_mass`.
+        Although we should then think about how to check the masses when
+        calculating the center of mass.
 
     """
     mdt.check.masses_new(ag=ag, verbose=debug)

--- a/scripts/script_template.py
+++ b/scripts/script_template.py
@@ -71,21 +71,26 @@ be called and their meaning.
 --sel       Selection string to select a group of atoms for the
             analysis.  See MDAnalysis' |selection_syntax| for possible
             choices.
---cmp       {'group', 'segments', 'residues', 'fragments', 'atoms'}
+--cmp       {'group', 'segments', 'residues', 'molecules', 'fragments',\
+            'atoms'}
 
             The compounds of the selection group to use for the
             analysis.  Compounds can be 'group' (the entire selection
-            group), 'segments', 'residues', 'fragments', or 'atoms'.
-            Refer to the MDAnalysis' user guide for an
+            group), 'segments', 'residues', 'molecules', 'fragments', or
+            'atoms'.  Refer to the MDAnalysis' user guide for an
             |explanation_of_these_terms|.  Note that in any case, even
             if ``CMP`` is e.g. 'residues', only the atoms belonging to
             the selection group are taken into account, even if the
             compound might comprise additional atoms that are not
             contained in the selection group.  Default: ``'atoms'``.
---center    {'cog', 'com'}
+--center    {'cog', 'com', 'coc'}
 
-            The center of the compounds to use for the analysis.  Choose
-            'cog' for center of geometry or 'com' for center of mass.
+            The center of the compounds to use for the analysis.
+
+                * ``'cog'``: Center of geometry
+                * ``'com'``: Center of mass
+                * ``'coc'``: Center of charge
+
             Note that |mda_always_guesses_atom_masses| from the atom
             types, even if the input file contains the masses.  Default:
             ``'cog'``.
@@ -236,7 +241,14 @@ if __name__ == "__main__":
         dest="CMP",
         type=str,
         required=False,
-        choices=("group", "segments", "residues", "fragments", "atoms"),
+        choices=(
+            "group",
+            "segments",
+            "residues",
+            "molecules",
+            "fragments",
+            "atoms",
+        ),
         default="atoms",
         help=(
             "The compounds of the selection group to use for the analysis."
@@ -248,7 +260,7 @@ if __name__ == "__main__":
         dest="CENTER",
         type=str,
         required=False,
-        choices=("cog", "com"),
+        choices=("cog", "com", "coc"),
         default="cog",
         help=(
             "The center of the compounds to use for the analysis.  Default:"
@@ -296,6 +308,16 @@ if __name__ == "__main__":
     trj = mdt.rti.ProgressBar(u.trajectory[BEGIN:END:EVERY])
     for ts in trj:
         # TODO: Put your computations here (preferably as function)
+        # Example for calculating different centers of compounds of an
+        # MDAnalysis AtomGroup:
+        pos = mdt.strc.center(
+            ag=sel,
+            center=args.CENTER,
+            pbc=True,
+            cmp=args.CMP,
+            make_whole=True,
+            debug=args.DEBUG,
+        )
         # ProgressBar update:
         trj.set_postfix_str(
             "{:>7.2f}MiB".format(mdt.rti.mem_usage(proc)), refresh=False


### PR DESCRIPTION
* Add new functions to calculate the center of geometry (`mdtools.structure.cog`), center of charge (`mdtools.structure.coc`) and a generic weighted center (`mdtools.structure.wcenter`) of (compounds of) an MDAnalysis AtomGroup.

* Refactor the center of mass function (`mdtools.structure.com`).

* Add a wrapper function (`mdtools.structure.center`) for the different center functions that can be used in MDTools scripts.