### PR TITLE
New script to calculate the RMSD as function of time

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -102,6 +102,7 @@ jobs:
         scripts/dynamics/plot_msd_layer*.py \
         scripts/structure/lig_change_at_pos_change_blocks.py \
         scripts/structure/plot_gmx_densmap.py \
+        scripts/structure/rmsd_vs_time.py \
         setup.py
     - name: Install/Upgrade flake8 and flake8-docstrings extension
       run: python -m pip install --user --upgrade flake8 flake8-docstrings

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -92,6 +92,7 @@ jobs:
         docs/source/conf.py \
         mdtools/__init__.py \
         mdtools/_metadata.py \
+        mdtools/box.py \
         mdtools/file_handler.py \
         mdtools/numpy_helper_functions.py \
         mdtools/plot.py \

--- a/docs/source/doc_pages/mdtools/mdtools.rst
+++ b/docs/source/doc_pages/mdtools/mdtools.rst
@@ -30,6 +30,7 @@ Modules
     :recursive:
     :nosignatures:
 
+    box
     check
     dtrj
     dynamics

--- a/docs/source/doc_pages/scripts/structure.rst
+++ b/docs/source/doc_pages/scripts/structure.rst
@@ -24,6 +24,7 @@ Scripts
     contact_hist
     lig_change_at_pos_change_blocks
     lig_change_at_pos_change_blocks_hist
+    rmsd_vs_time
 
 
 Plot scripts

--- a/mdtools/box.py
+++ b/mdtools/box.py
@@ -683,15 +683,15 @@ def vdist(pos1, pos2, box=None, out=None):
     ...                  [0, 2, 4]])
     >>> mdt.box.vdist(pos1, pos2)
     array([[-5., -1.,  3.],
-    ...    [ 5.,  1., -3.]])
+           [ 5.,  1., -3.]])
     >>> mdt.box.vdist(pos1, pos2, box=box)
     array([[ 1., -1., -1.],
-    ...    [-1., -1., -1.]])
+           [-1., -1., -1.]])
     >>> box = np.array([[3, 2, 2, 90, 90, 90],
     ...                 [2, 3, 4, 90, 90, 90]])
     >>> mdt.box.vdist(pos1, pos2, box=box)
     array([[ 1., -1., -1.],
-    ...    [-1.,  1.,  1.]])
+           [-1.,  1.,  1.]])
 
     Shape of `pos1` and `pos2` is ``(k, n, 3)``:
 
@@ -734,16 +734,16 @@ def vdist(pos1, pos2, box=None, out=None):
     ...                  [0, 2, 4]])
     >>> mdt.box.vdist(pos1, pos2)
     array([[-5., -1.,  3.],
-    ...    [ 0.,  0.,  0.]])
+           [ 0.,  0.,  0.]])
     >>> box = np.array([3, 2, 2, 90, 90, 90])
     >>> mdt.box.vdist(pos1, pos2, box=box)
     array([[ 1., -1., -1.],
-    ...    [ 0.,  0.,  0.]])
+           [ 0.,  0.,  0.]])
     >>> box = np.array([[3, 2, 2, 90, 90, 90],
     ...                 [2, 3, 4, 90, 90, 90]])
     >>> mdt.box.vdist(pos1, pos2, box=box)
     array([[ 1., -1., -1.],
-    ...    [ 0.,  0.,  0.]])
+           [ 0.,  0.,  0.]])
 
     Shape of `pos1` is ``(3,)`` and shape of `pos2` is ``(k, n, 3)``:
 

--- a/mdtools/box.py
+++ b/mdtools/box.py
@@ -21,12 +21,14 @@
 
 # Standard libraries
 from datetime import datetime
+
 # Third party libraries
 import psutil
 import numpy as np
 import MDAnalysis as mda
 import MDAnalysis.lib.distances as mdadist
 import MDAnalysis.lib.mdamath as mdamath
+
 # Local application/library specific imports
 import mdtools as mdt
 
@@ -77,8 +79,9 @@ def box_volume(box, debug=False):
     volume = mdamath.box_volume(box)
     if volume <= 0:
         mdt.check.box(box=box, with_angles=True, dim=1)
-        raise ValueError("The box volume ({}) is equal to or less than"
-                         " zero".format(volume))
+        raise ValueError(
+            "The box volume ({}) is equal to or less than zero".format(volume)
+        )
     return volume
 
 
@@ -132,7 +135,7 @@ def volume(box, debug=False, **kwargs):
     lengths using :func:`numpy.prod`.
     """
     mdt.check.box(box=box, orthorhombic=True)
-    kwargs.pop('axis', None)
+    kwargs.pop("axis", None)
     return np.prod(box, axis=-1, **kwargs)
 
 
@@ -317,8 +320,8 @@ def wrap_pos(pos, box, mda_backend=None):
 
 
 def wrap(
-        ag, compound='atoms', center='cog', box=None, inplace=True,
-        debug=False):
+    ag, compound="atoms", center="cog", box=None, inplace=True, debug=False
+):
     """
     Shift compounds of an MDAnalysis
     :class:`~MDAnalysis.core.groups.AtomGroup` back into the primary
@@ -335,7 +338,8 @@ def wrap(
     ag : MDAnalysis.core.groups.AtomGroup instance
         The MDAnalysis :class:`~MDAnalysis.core.groups.AtomGroup` whose
         compounds shall be wrapped back into the primary unit cell.
-    compound : {'atoms', 'group', 'segments', 'residues', 'molecules', 'fragments'}, optional
+    compound : {'atoms', 'group', 'segments', 'residues', 'molecules', \
+        'fragments'}, optional
         Which type of compound to keep together during wrapping.
         :class:`Atoms <MDAnalysis.core.groups.Atom>` belonging to the
         same compound are shifted by the same translation vector such
@@ -348,16 +352,13 @@ def wrap(
         individual translation vector so that finally all
         :class:`Atoms <MDAnalysis.core.groups.Atom>` of `ag` will be
         inside the unit cell.  Refer to the MDAnalysis' user guide
-        for an `explanation of the terms`_.  Note that in any case,
+        for an |explanation_of_these_terms|.  Note that in any case,
         even if `compound` is e.g. ``'residues'``, only the
         :class:`Atoms <MDAnalysis.core.groups.Atom>` belonging to `ag`
         are taken into account, even if the compound might comprise
         additional :class:`Atoms <MDAnalysis.core.groups.Atom>` that are
         not contained in `ag`.  Also note that broken compounds are
         note made whole by this function.
-
-        .. _explanation of the terms: https://userguide.mdanalysis.org/stable/groups_of_atoms.html
-
     center : {'cog', 'com'}, optional
         How to define the center of a compound.  Parse ``'cog'`` for
         center of geometry or ``'com'`` for center of mass.  If compound
@@ -386,8 +387,9 @@ def wrap(
     See Also
     --------
     :meth:`MDAnalysis.core.groups.AtomGroup.wrap` :
-        Shift compounds of the :class:`~MDAnalysis.core.groups.AtomGroup`
-        back into the primary unit cell
+        Shift compounds of the
+        :class:`~MDAnalysis.core.groups.AtomGroup` back into the primary
+        unit cell
     :meth:`MDAnalysis.core.groups.AtomGroup.pack_into_box`
         Shift all :class:`Atoms <MDAnalysis.core.groups.Atom>` in the
         :class:`~MDAnalysis.core.groups.AtomGroup` into the primary unit
@@ -430,24 +432,23 @@ def wrap(
     MDAnalysis user guide about trajectories_ (second last
     paragraph) and `in-memory trajectories`_.
 
-    .. _trajectories: https://userguide.mdanalysis.org/stable/trajectories/trajectories.html
-    .. _in-memory trajectories: https://userguide.mdanalysis.org/stable/reading_and_writing.html#in-memory-trajectories
+    .. _trajectories:
+        https://userguide.mdanalysis.org/stable/trajectories/trajectories.html
+    .. _in-memory trajectories:
+        https://userguide.mdanalysis.org/stable/reading_and_writing.html#in-memory-trajectories
     """
     if ag.n_atoms == 1:
         # => 'com' and 'cog' are the same, but because the mass might be
         # zero, it is safer to use 'cog'
-        center = 'cog'
-    elif center == 'com' and compound != 'atoms':  # and ag.n_atoms > 1
+        center = "cog"
+    elif center == "com" and compound != "atoms":  # and ag.n_atoms > 1
         mdt.check.masses_new(ag=ag, verbose=debug)
-    return ag.wrap(compound=compound,
-                   center=center,
-                   box=box,
-                   inplace=inplace)
+    return ag.wrap(compound=compound, center=center, box=box, inplace=inplace)
 
 
 def make_whole(
-        ag, compound='fragments', reference='cog', inplace=True,
-        debug=False):
+    ag, compound="fragments", reference="cog", inplace=True, debug=False
+):
     """
     Make compounds of a MDAnalysis
     :class:`~MDAnalysis.core.groups.AtomGroup` whole that are split
@@ -462,7 +463,8 @@ def make_whole(
     ag : MDAnalysis.core.groups.AtomGroup instance
         The MDAnalysis :class:`~MDAnalysis.core.groups.AtomGroup` whose
         compounds shall be made whole.
-    compound : {'group', 'segments', 'residues', 'molecules', 'fragments'}, optional
+    compound : {'group', 'segments', 'residues', 'molecules', \
+        'fragments'}, optional
         Which type of component to make whole.  Note that in any case,
         all :class:`Atoms <MDAnalysis.core.groups.Atom>` within each
         compound must be interconnected by bonds, i.e. compounds must
@@ -489,7 +491,8 @@ def make_whole(
         :class:`Atoms <MDAnalysis.core.groups.Atom>` of these molecules
         are part of `ag`.
 
-        .. _MDAnalysis user guide: https://userguide.mdanalysis.org/stable/groups_of_atoms.html
+        .. _MDAnalysis user guide:
+            https://userguide.mdanalysis.org/stable/groups_of_atoms.html
 
     reference : {'cog', 'com', None}, optional
         If 'cog' (center of geometry) or 'com' (center of mass), the
@@ -530,16 +533,16 @@ def make_whole(
     :meth:`~MDAnalysis.core.groups.AtomGroup.unwrap` method of the
     input :class:`~MDAnalysis.core.groups.AtomGroup` that additionally
     checks the masses of all
-    :class:`Atoms <MDAnalysis.core.groups.Atom>` in `ag` when `reference`
-    is set to ``'com'``.  See :func:`mdtools.check.masses_new` for
-    further information.
+    :class:`Atoms <MDAnalysis.core.groups.Atom>` in `ag` when
+    `reference` is set to ``'com'``.  See
+    :func:`mdtools.check.masses_new` for further information.
 
     Before making any compound whole, all
     :class:`Atoms <MDAnalysis.core.groups.Atom>` in `ag` are wrapped
     back into the primary unit cell.  This is done to make sure that the
     unwrap algorithm (better "make whole" algorithm) of
-    :meth:`~MDAnalysis.core.groups.AtomGroup.unwrap` is working properly.
-    This means that making compounds whole in an unwrapped
+    :meth:`~MDAnalysis.core.groups.AtomGroup.unwrap` is working
+    properly.  This means that making compounds whole in an unwrapped
     :attr:`~MDAnalysis.core.universe.Universe.trajectory` while keeping
     the :attr:`~MDAnalysis.core.universe.Universe.trajectory` unwrapped
     is not possible with this function.
@@ -568,25 +571,28 @@ def make_whole(
     MDAnalysis user guide about trajectories_ (second last
     paragraph) and `in-memory trajectories`_.
 
-    .. _trajectories: https://userguide.mdanalysis.org/stable/trajectories/trajectories.html
-    .. _in-memory trajectories: https://userguide.mdanalysis.org/stable/reading_and_writing.html#in-memory-trajectories
+    .. _trajectories:
+        https://userguide.mdanalysis.org/stable/trajectories/trajectories.html
+    .. _in-memory trajectories:
+        https://userguide.mdanalysis.org/stable/reading_and_writing.html#in-memory-trajectories
     """
     if ag.n_atoms == 1:
         # => 'com' and 'cog' are the same, but because the mass might be
         # zero, it is safer to use 'cog'
-        reference = 'cog'
-    elif reference == 'com':  # and ag.n_atoms > 1
+        reference = "cog"
+    elif reference == "com":  # and ag.n_atoms > 1
         mdt.check.masses_new(ag=ag, verbose=debug)
-    wrap(ag=ag,
-         compound='atoms',
-         center='cog',
-         box=None,
-         inplace=True,
-         debug=debug)
-    return ag.unwrap(compound=compound,
-                     reference=reference,
-                     inplace=inplace,
-                     debug=debug)
+    wrap(
+        ag=ag,
+        compound="atoms",
+        center="cog",
+        box=None,
+        inplace=True,
+        debug=debug,
+    )
+    return ag.unwrap(
+        compound=compound, reference=reference, inplace=inplace, debug=debug
+    )
 
 
 def vdist(pos1, pos2, box=None, out=None):
@@ -821,14 +827,20 @@ def vdist(pos1, pos2, box=None, out=None):
             # This else clause should never be entered, because this
             # error should already be raised by `mdt.check.box(box)`.
             raise ValueError(
-                "{}".format(box.shape)
+                "'box' must have shape (6,) or (k, 6), but has shape"
+                " {}".format(box.shape)
             )
         dist_vecs -= np.floor(dist_vecs / box + 0.5) * box
     return dist_vecs
 
 
-def unwrap(atm_grp, coord_unwrapped_prev, displacement=None,
-           inplace=False, debug=False):
+def unwrap(
+    atm_grp,
+    coord_unwrapped_prev,
+    displacement=None,
+    inplace=False,
+    debug=False,
+):
     """
     Unwrap the atoms of a MDAnalysis
     :class:`~MDAnalysis.core.groups.AtomGroup` out of the primary unit
@@ -855,7 +867,7 @@ def unwrap(atm_grp, coord_unwrapped_prev, displacement=None,
     the change with that from the file except if the
     :attr:`~MDAnalysis.core.universe.Universe.trajectory` is held in
     memory, e.g., when the
-    :method:`~MDAnalysis.core.universe.Universe.transfer_to_memory`
+    :meth:`~MDAnalysis.core.universe.Universe.transfer_to_memory`
     method was used.
 
     Parameters
@@ -870,10 +882,10 @@ def unwrap(atm_grp, coord_unwrapped_prev, displacement=None,
         `coord_unwrapped_prev` should be the wrapped coordinates of
         `atm_grp` from the very first frame and `atm_grp` should be
         parsed from the second frame so that ``atm_grp.positions``
-        contains the atom coordinates of `atm_grp` from the second frame.
-        For all further frames, `coord_unwrapped_prev` should be the
-        result of this function and `atm_grp` should be parsed from next
-        frame.
+        contains the atom coordinates of `atm_grp` from the second
+        frame.  For all further frames, `coord_unwrapped_prev` should be
+        the result of this function and `atm_grp` should be parsed from
+        next frame.
     displacement : numpy.ndarray, optional
         Preallocated temporary array of the same shape as
         ``atm_grp.positions.shape`` and dtype ``numpy.float64``. If
@@ -897,12 +909,13 @@ def unwrap(atm_grp, coord_unwrapped_prev, displacement=None,
         nominally ``coord_unwrapped_prev + displacement``.
     """
     if debug:
-        mdt.check.pos_array(coord_unwrapped_prev,
-                            shape=atm_grp.positions.shape)
+        mdt.check.pos_array(
+            coord_unwrapped_prev, shape=atm_grp.positions.shape
+        )
         if displacement is not None:
-            mdt.check.pos_array(displacement,
-                                shape=atm_grp.positions.shape,
-                                dtype=np.float64)
+            mdt.check.pos_array(
+                displacement, shape=atm_grp.positions.shape, dtype=np.float64
+            )
 
     displacement = mdt.box.vdist(
         pos1=atm_grp.positions,
@@ -917,9 +930,19 @@ def unwrap(atm_grp, coord_unwrapped_prev, displacement=None,
         return coord_unwrapped_prev + displacement
 
 
-def unwrap_trj(topfile, trjfile, universe, atm_grp, end=-1,
-               make_whole=False, keep_whole=False, compound='fragments',
-               reference='com', verbose=False, debug=False):
+def unwrap_trj(
+    topfile,
+    trjfile,
+    universe,
+    atm_grp,
+    end=-1,
+    make_whole=False,
+    keep_whole=False,
+    compound="fragments",
+    reference="com",
+    verbose=False,
+    debug=False,
+):
     """
     Unwrap the atoms of a MDAnalysis
     :class:`~MDAnalysis.core.groups.AtomGroup` out of the primary unit
@@ -952,6 +975,10 @@ def unwrap_trj(topfile, trjfile, universe, atm_grp, end=-1,
         the unwrapping precedure is done, you can create a new universe
         from this unwrapped trajectory and topology. See the
         `MDAnalysis user guide`_ for supported file formats.
+
+        .. _MDAnalysis user guide:
+            https://userguide.mdanalysis.org/1.0.0/formats/index.html
+
     universe : MDAnalysis.core.universe.Universe
         The universe holding the trajectory and
         :class:`~MDAnalysis.core.groups.AtomGroup` to unwrap. You cannot
@@ -999,31 +1026,34 @@ def unwrap_trj(topfile, trjfile, universe, atm_grp, end=-1,
         If ``True``, print progress information to standard output.
     debug : bool, optional
         If ``True``, check the input arguments.
-
-    .. _MDAnalysis user guide: https://userguide.mdanalysis.org/1.0.0/formats/index.html
     """
-
     if debug:
         if isinstance(atm_grp, mda.core.groups.UpdatingAtomGroup):
-            raise TypeError("atm_grp must not be an"
-                            " MDAnalysis.core.groups.UpdatingAtomGroup")
-        if (make_whole and
-            compound != 'group' and
-            compound != 'segments' and
-            compound != 'residues' and
-            compound != 'molecules' and
-                compound != 'fragments'):
-            raise ValueError("compound must be either 'group',"
-                             " 'segments', 'residues', 'molecules' or"
-                             " 'fragments', but you gave '{}'"
-                             .format(compound))
-        if (make_whole and
-            reference != 'com' and
-            reference != 'cog' and
-                reference is not None):
-            raise ValueError("reference must be either 'com', 'cog' or"
-                             " None, but you gave {}".format(reference))
-        if make_whole and reference == 'com':
+            raise TypeError("atm_grp must not be an UpdatingAtomGroup")
+        if (
+            make_whole
+            and compound != "group"
+            and compound != "segments"
+            and compound != "residues"
+            and compound != "molecules"
+            and compound != "fragments"
+        ):
+            raise ValueError(
+                "compound must be either 'group',"
+                " 'segments', 'residues', 'molecules' or"
+                " 'fragments', but you gave '{}'".format(compound)
+            )
+        if (
+            make_whole
+            and reference != "com"
+            and reference != "cog"
+            and reference is not None
+        ):
+            raise ValueError(
+                "reference must be either 'com', 'cog' or None, but you gave"
+                " {}".format(reference)
+            )
+        if make_whole and reference == "com":
             mdt.check.masses(ag=atm_grp, flash_test=False)
         if make_whole and len(atm_grp.bonds) <= 0:
             raise ValueError("The AtomGroup contains no bonds")
@@ -1031,10 +1061,8 @@ def unwrap_trj(topfile, trjfile, universe, atm_grp, end=-1,
     if end < 0:
         end = universe.trajectory.n_frames
     _, end, _, _ = mdt.check.frame_slicing(
-        start=0,
-        stop=end,
-        step=1,
-        n_frames_tot=universe.trajectory.n_frames)
+        start=0, stop=end, step=1, n_frames_tot=universe.trajectory.n_frames
+    )
     displacement = np.zeros(atm_grp.positions.shape, dtype=np.float64)
 
     ts = universe.trajectory[0]
@@ -1043,29 +1071,33 @@ def unwrap_trj(topfile, trjfile, universe, atm_grp, end=-1,
         proc = psutil.Process()
         last_frame = universe.trajectory[end - 1].frame
         ts = universe.trajectory[0]
-        print("  Frame   {:12d}".format(ts.frame), flush=True)
-        print("    Step: {:>12}    Time: {:>12} (ps)"
-              .format(ts.data['step'], ts.data['time']),
-              flush=True)
-        print("    Elapsed time:             {}"
-              .format(datetime.now() - timer),
-              flush=True)
-        print("    Current memory usage: {:18.2f} MiB"
-              .format(proc.memory_info().rss / 2**20),
-              flush=True)
+        print("  Frame   {:12d}".format(ts.frame))
+        print(
+            "    Step: {:>12}    Time: {:>12} (ps)".format(
+                ts.data["step"], ts.data["time"]
+            ),
+        )
+        print(
+            "    Elapsed time:             {}".format(datetime.now() - timer),
+        )
+        print(
+            "    Current memory usage: {:18.2f} MiB".format(
+                proc.memory_info().rss / 2**20
+            ),
+        )
         timer = datetime.now()
     if debug:
         mdt.check.box(box=ts.dimensions, with_angles=True, dim=1)
     if make_whole or keep_whole:
-        coord_unwrapped = mdt.box.make_whole(ag=atm_grp,
-                                             compound=compound,
-                                             reference=reference,
-                                             inplace=True,
-                                             debug=debug)
+        coord_unwrapped = mdt.box.make_whole(
+            ag=atm_grp,
+            compound=compound,
+            reference=reference,
+            inplace=True,
+            debug=debug,
+        )
     else:
-        coord_unwrapped = mdt.box.wrap(ag=atm_grp,
-                                       inplace=True,
-                                       debug=debug)
+        coord_unwrapped = mdt.box.wrap(ag=atm_grp, inplace=True, debug=debug)
 
     mdt.fh.backup(topfile)
     atm_grp.write(topfile)
@@ -1073,37 +1105,48 @@ def unwrap_trj(topfile, trjfile, universe, atm_grp, end=-1,
     with mda.Writer(trjfile, atm_grp.n_atoms) as w:
         w.write(atm_grp)
         for ts in universe.trajectory[1:end]:
-            if (verbose and
-                (ts.frame % 10**(len(str(ts.frame)) - 1) == 0 or
-                 ts.frame == last_frame)):
-                print("  Frame   {:12d}".format(ts.frame), flush=True)
-                print("    Step: {:>12}    Time: {:>12} (ps)"
-                      .format(ts.data['step'], ts.data['time']),
-                      flush=True)
-                print("    Elapsed time:             {}"
-                      .format(datetime.now() - timer),
-                      flush=True)
-                print("    Current memory usage: {:18.2f} MiB"
-                      .format(proc.memory_info().rss / 2**20),
-                      flush=True)
+            if verbose and (
+                ts.frame % 10 ** (len(str(ts.frame)) - 1) == 0
+                or ts.frame == last_frame
+            ):
+                print("  Frame   {:12d}".format(ts.frame))
+                print(
+                    "    Step: {:>12}    Time: {:>12} (ps)".format(
+                        ts.data["step"], ts.data["time"]
+                    ),
+                )
+                print(
+                    "    Elapsed time:             {}".format(
+                        datetime.now() - timer
+                    ),
+                )
+                print(
+                    "    Current memory usage: {:18.2f} MiB".format(
+                        proc.memory_info().rss / 2**20
+                    ),
+                )
                 timer = datetime.now()
             if debug:
                 mdt.check.box(box=ts.dimensions, with_angles=True, dim=1)
             if make_whole:
-                mdt.box.make_whole(ag=atm_grp,
-                                   compound=compound,
-                                   reference=reference,
-                                   inplace=True,
-                                   debug=debug)
-            mdt.box.unwrap(atm_grp=atm_grp,
-                           coord_unwrapped_prev=coord_unwrapped,
-                           displacement=displacement,
-                           inplace=True,
-                           debug=debug)
+                mdt.box.make_whole(
+                    ag=atm_grp,
+                    compound=compound,
+                    reference=reference,
+                    inplace=True,
+                    debug=debug,
+                )
+            mdt.box.unwrap(
+                atm_grp=atm_grp,
+                coord_unwrapped_prev=coord_unwrapped,
+                displacement=displacement,
+                inplace=True,
+                debug=debug,
+            )
             atm_grp.positions = coord_unwrapped
             w.write(atm_grp)
 
     if verbose:
-        print(flush=True)
-        print("  Created {}".format(topfile), flush=True)
-        print("  Created {}".format(trjfile), flush=True)
+        print()
+        print("  Created {}".format(topfile))
+        print("  Created {}".format(trjfile))

--- a/mdtools/structure.py
+++ b/mdtools/structure.py
@@ -189,13 +189,13 @@ def wcenter_pos(
     ...                 [2, 1, 4, 90, 90, 90]])
     >>> mdt.strc.wcenter_pos(pos, box=box)
     array([[0, 2, 5],
-    ...    [1, 0, 1]])
+           [1, 0, 1]])
     >>> mdt.strc.wcenter_pos(pos, wrap_pos=True, box=box)
     array([[0., 0., 1.],
-    ...    [1., 0., 1.]], dtype=float32)
+           [1., 0., 1.]], dtype=float32)
     >>> mdt.strc.wcenter_pos(pos, wrap_result=True, box=box)
     array([[0., 0., 1.],
-    ...    [1., 0., 1.]], dtype=float32)
+           [1., 0., 1.]], dtype=float32)
 
     Shape of `pos` is ``(k, n, 3)``:
 
@@ -206,7 +206,7 @@ def wcenter_pos(
     ...                  [0, 2, 5]]])
     >>> mdt.strc.wcenter_pos(pos)
     array([[0.5, 1. , 3. ],
-    ...    [0.5, 1. , 3. ]])
+           [0.5, 1. , 3. ]])
     >>> mdt.strc.wcenter_pos(pos, weights=[3, 1])
     array([[0.25, 1.5 , 4.  ],
            [0.75, 0.5 , 2.  ]])
@@ -221,10 +221,10 @@ def wcenter_pos(
     ...                 [2, 1, 4, 90, 90, 90]])
     >>> mdt.strc.wcenter_pos(pos, wrap_pos=True, box=box)
     array([[0.5, 0. , 1. ],
-    ...    [0.5, 0. , 1. ]], dtype=float32)
+           [0.5, 0. , 1. ]], dtype=float32)
     >>> mdt.strc.wcenter_pos(pos, wrap_result=True, box=box)
     array([[0.5, 1. , 1. ],
-    ...    [0.5, 0. , 3. ]], dtype=float32)
+           [0.5, 0. , 3. ]], dtype=float32)
     """
     pos = mdt.check.pos_array(pos)
     if box is None and (wrap_pos or wrap_result):

--- a/mdtools/structure.py
+++ b/mdtools/structure.py
@@ -3828,9 +3828,8 @@ def rmsd(
         contained in the position arrays.  If `weights` is ``None``, all
         particles are assumed to have a weight equal to one.
     center : bool, optional
-        If ``True``, shift the reference and candidate particles by
-        their weighted center, respectively, before calculating the
-        RMSD.
+        If ``True``, shift the `refpos` and `selpos` by their (weighted)
+        center, respectively, before calculating the RMSD.
     inplace : bool, optional
         If ``True``, subtract the weighted center from the reference and
         candidate positions in place (i.e. the input arrays will be

--- a/mdtools/structure.py
+++ b/mdtools/structure.py
@@ -131,6 +131,8 @@ def center(
     :func:`mdtools.structure.wcenter` :
         Weighted center of (compounds of) an MDAnalysis
         :class:`~MDAnalysis.core.groups.AtomGroup`
+    :func:`mdtools.structure.wcenter_pos` :
+        Calculate the weighted center of a position array
     :func:`mdtools.structure.coc` :
         Center of charge of (compounds of) an MDAnalysis
         :class:`~MDAnalysis.core.groups.AtomGroup`
@@ -498,6 +500,8 @@ def wcenter(
     :func:`mdtools.structure.center` :
         Different types of centers of (compounds of) an MDAnalysis
         :class:`~MDAnalysis.core.groups.AtomGroup`
+    :func:`mdtools.structure.wcenter_pos` :
+        Calculate the weighted center of a position array
     :func:`mdtools.structure.coc` :
         Center of charge of (compounds of) an MDAnalysis
         :class:`~MDAnalysis.core.groups.AtomGroup`
@@ -630,6 +634,8 @@ def coc(ag, pbc=False, cmp='group', make_whole=False, debug=False):
     :func:`mdtools.structure.wcenter` :
         Weighted center of (compounds of) an MDAnalysis
         :class:`~MDAnalysis.core.groups.AtomGroup`
+    :func:`mdtools.structure.wcenter_pos` :
+        Calculate the weighted center of a position array
     :func:`mdtools.structure.cog` :
         Center of geometry of (compounds of) an MDAnalysis
         :class:`~MDAnalysis.core.groups.AtomGroup`
@@ -711,6 +717,8 @@ def cog(ag, pbc=False, cmp='group', make_whole=False, debug=False):
     :func:`mdtools.structure.wcenter` :
         Weighted center of (compounds of) an MDAnalysis
         :class:`~MDAnalysis.core.groups.AtomGroup`
+    :func:`mdtools.structure.wcenter_pos` :
+        Calculate the weighted center of a position array
     :func:`mdtools.structure.coc` :
         Center of charge of (compounds of) an MDAnalysis
         :class:`~MDAnalysis.core.groups.AtomGroup`
@@ -817,6 +825,8 @@ def com(ag, pbc=False, compound='group', make_whole=False, debug=False):
     :func:`mdtools.structure.wcenter` :
         Weighted center of (compounds of) an MDAnalysis
         :class:`~MDAnalysis.core.groups.AtomGroup`
+    :func:`mdtools.structure.wcenter_pos` :
+        Calculate the weighted center of a position array
     :func:`mdtools.structure.coc` :
         Center of charge of (compounds of) an MDAnalysis
         :class:`~MDAnalysis.core.groups.AtomGroup`

--- a/mdtools/structure.py
+++ b/mdtools/structure.py
@@ -238,13 +238,13 @@ def wcenter_pos(
     # `mdtools.check.pos_array`).  If `ndim` is
     #     * 1 (single particle), the center is simply the particle
     #       position.
-    #     * 2 and box.ndim is 2 (multiple frames, single particles), the
-    #       center is simply the particle position.
-    #     * 2 and box.ndim is 1 (single frame, multiple particles), the
-    #       center is the average over all particle positions
+    #     * 2 and ``box.ndim`` is 2 (multiple frames, single particles),
+    #       the center is simply the particle position in each frame.
+    #     * 2 and ``box.ndim`` is 1 (single frame, multiple particles),
+    #       the center is the average over all particle positions
     #       (``axis=0``).
-    #     * 3 (multiple frames), the centers are the averages over
-    #       all particle positions in each frame (``axis=1``).
+    #     * 3 (multiple frames), the center is the average over all
+    #       particle positions in each frame (``axis=1``).
     if pos.ndim == 1:
         center = pos
     elif box is not None and box.ndim == 2 and pos.ndim == 2:

--- a/mdtools/structure.py
+++ b/mdtools/structure.py
@@ -3791,3 +3791,399 @@ def contact_hists(
             hist_refcmp_same_selcmp,
             hist_refcmp_selcmp_tot,
             hist_refcmp_selcmp_pair)
+
+
+def rmsd(
+    refpos,
+    selpos,
+    weights=None,
+    center=False,
+    inplace=False,
+    xyz=False,
+    box=None,
+):
+    r"""
+    Calculate the Root Mean Square Deviation (RMSD) between two sets of
+    positions.
+
+    .. todo::
+
+        Implement a "superposition" functionality like in
+        :func:`MDAnalysis.analysis.rms.rmsd`.
+
+    Parameters
+    ----------
+    refpos, selpos : array_like
+        Reference and candidate set of positions.  Position arrays must
+        be of shape ``(3,)``, ``(n, 3)`` or ``(k, n, 3)`` where ``n`` is
+        the number of particles and ``k`` is the number of frames.
+        `refpos` and `selpos` must contain the same number of particles
+        ``n``, but can have different numbers of frames ``k``.  If
+        `refpos` and `selpos` do not have the same shape, they must be
+        broadcastable to a common shape (which becomes the shape of the
+        output).  The user is responsible to provide inputs that result
+        in a physically meaningful broadcasting!
+    weights : None or array_like, optional
+        Array of shape ``(n,)`` containing the weight of each particle
+        contained in the position arrays.  If `weights` is ``None``, all
+        particles are assumed to have a weight equal to one.
+    center : bool, optional
+        If ``True``, shift the reference and candidate particles by
+        their weighted center, respectively, before calculating the
+        RMSD.
+    inplace : bool, optional
+        If ``True``, subtract the weighted center from the reference and
+        candidate positions in place (i.e. the input arrays will be
+        changed).  Note that `refpos` and `selpos` must have an
+        appropriate dtype in this case.
+    xyz : bool, optional
+        If ``True``, return the x, y and z component of the RMSD
+        separately instead of summing all components.  Note however,
+        that in this case the square root is not taken, because you
+        cannot extract the square root of each summand individually.
+    box : None or array_like, optional
+        The unit cell dimensions of the system, which must be orthogonal
+        and provided in the same format as returned by
+        :attr:`MDAnalysis.coordinates.base.Timestep.dimensions`:
+        ``[lx, ly, lz, alpha, beta, gamma]``.  `box` can also be an
+        array of boxes of shape ``(k, 6)``, where ``k`` must match the
+        number of frames in `refpos`.  If given, the minimum image
+        convention is taken into account when calculating the distance
+        between the reference and candidate positions.  Works currently
+        only for orthogonal boxes.
+
+    Raises
+    ------
+    ValueError :
+        If `weights` is not of shape ``(n,)`` or if it sums up to zero.
+
+    See Also
+    --------
+    :class:`MDAnalysis.analysis.rms.RMSD` :
+        Class to perform RMSD analysis on a trajectory
+    :func:`MDAnalysis.analysis.rms.rmsd` :
+        Calculate the RMSD between two coordinate sets
+
+    Notes
+    -----
+    The root mean square deviation is calculated by
+
+    .. math::
+
+        RMSD = \sqrt{\frac{1}{N} \frac{1}{W} \sum_i^N w_i \
+        \left( \mathbf{r}_i - \mathbf{r}_i^{ref} \right)^2}
+
+    where :math:`N` is the number of particles,
+    :math:`w_i` is the weight of the :math:`i`-th particle,
+    :math:`W = \sum_i^N w_i` is the sum of particle weights,
+    :math:`\mathbf{r}_i` are the candidate positions and
+    :math:`\mathbf{r}_i^{ref}` are the reference positions.
+
+    If `xyz` is ``True``, each component of the RMSD is returned
+    individually without taking the square root.  For instance, the
+    :math:`x`-component is
+
+    .. math::
+
+        \langle \Delta x^2 \rangle = \frac{1}{N} \frac{1}{W} \
+        \sum_i^N w_i \left( x_i - x_i^{ref} \right)^2.
+
+    Examples
+    --------
+    Shape of `refpos` and `selpos` is ``(3,)``:
+
+    >>> refpos = np.array([ 3,  4,  5])
+    >>> selpos = np.array([ 1,  7, -1])
+    >>> selpos - refpos
+    array([-2,  3, -6])
+    >>> mdt.strc.rmsd(refpos, selpos)
+    7.0
+    >>> mdt.strc.rmsd(refpos, selpos, xyz=True)
+    array([ 4.,  9., 36.])
+    >>> box = np.array([5, 3, 3, 90, 90, 90])
+    >>> mdt.strc.rmsd(refpos, selpos, xyz=True, box=box)
+    array([4., 0., 0.])
+    >>> mdt.strc.rmsd(refpos, selpos, box=box)
+    2.0
+    >>> mdt.strc.rmsd(refpos, selpos, weights=[3])
+    7.0
+    >>> mdt.strc.rmsd(refpos, selpos, weights=[3], center=True)
+    0.0
+    >>> mdt.strc.rmsd(refpos, selpos, center=True, inplace=True)
+    0.0
+    >>> refpos
+    array([0, 0, 0])
+    >>> selpos
+    array([0, 0, 0])
+
+    Shape of `refpos` and `selpos` is ``(n, 3)``:
+
+    >>> refpos = np.array([[ 3.,  4.,  5.],
+    ...                    [ 1., -1.,  1.]])
+    >>> selpos = np.array([[ 1.,  7., -1.],
+    ...                    [-1.,  0., -1.]])
+    >>> selpos - refpos
+    array([[-2.,  3., -6.],
+           [-2.,  1., -2.]])
+    >>> rmsd = mdt.strc.rmsd(refpos, selpos)
+    >>> rmsd_expected = np.sqrt(0.5 * (49 + 9))
+    >>> np.isclose(rmsd, rmsd_expected, rtol=0)
+    True
+    >>> mdt.strc.rmsd(refpos, selpos, xyz=True)
+    array([ 4.,  5., 20.])
+    >>> mdt.strc.rmsd(refpos, selpos, xyz=True, box=box)
+    array([4. , 0.5, 0.5])
+    >>> weights = np.array([0.575, 0.425])
+    >>> rmsd = mdt.strc.rmsd(refpos, selpos, weights=weights)
+    >>> np.isclose(rmsd, 4, rtol=0)
+    True
+    >>> mdt.strc.rmsd(refpos, selpos, weights=weights, center=True)
+    1.5632498200863483
+    >>> mdt.strc.rmsd(
+    ...     refpos, selpos, xyz=True, center=True, inplace=True
+    ... )
+    array([0., 1., 4.])
+    >>> refpos
+    array([[ 1. ,  2.5,  2. ],
+           [-1. , -2.5, -2. ]])
+    >>> selpos
+    array([[ 1. ,  3.5,  0. ],
+           [-1. , -3.5,  0. ]])
+
+    Shape of `refpos` and `selpos` is ``(k, n, 3)``:
+
+    >>> refpos = np.array([[[ 3.,  4.,  5.],
+    ...                     [ 1., -1.,  1.]],
+    ...
+    ...                    [[ 5.,  0.,  1.],
+    ...                     [ 1.,  2., -3.]]])
+    >>> selpos = np.array([[[ 1.,  7., -1.],
+    ...                     [-1.,  0., -1.]],
+    ...
+    ...                    [[ 3.,  4.,  5.],
+    ...                     [ 1., -1.,  1.]]])
+    >>> selpos - refpos
+    array([[[-2.,  3., -6.],
+            [-2.,  1., -2.]],
+    <BLANKLINE>
+           [[-2.,  4.,  4.],
+            [ 0., -3.,  4.]]])
+    >>> rmsd = mdt.strc.rmsd(refpos, selpos)
+    >>> rmsd_expected = np.sqrt(0.5 * np.array([49 + 9, 36 + 25]))
+    >>> np.allclose(rmsd, rmsd_expected, rtol=0)
+    True
+    >>> mdt.strc.rmsd(refpos, selpos, xyz=True)
+    array([[ 4. ,  5. , 20. ],
+           [ 2. , 12.5, 16. ]])
+    >>> mdt.strc.rmsd(refpos, selpos, xyz=True, box=box)
+    array([[4. , 0.5, 0.5],
+           [2. , 0.5, 1. ]])
+    >>> box = np.array([[5, 3, 3, 90, 90, 90],
+    ...                 [3, 5, 5, 90, 90, 90]])
+    >>> mdt.strc.rmsd(refpos, selpos, xyz=True, box=box)
+    array([[4. , 0.5, 0.5],
+           [0.5, 2.5, 1. ]])
+    >>> rmsd = mdt.strc.rmsd(refpos, selpos, weights=weights)
+    >>> rmsd_expected = np.sqrt([16.    , 15.6625])
+    >>> np.allclose(rmsd, rmsd_expected, rtol=0)
+    True
+    >>> mdt.strc.rmsd(refpos, selpos, weights=weights, center=True)
+    array([1.56324982, 2.54478634])
+    >>> mdt.strc.rmsd(
+    ...    refpos, selpos, xyz=True, center=True, inplace=True
+    ... )
+    array([[ 0.  ,  1.  ,  4.  ],
+           [ 1.  , 12.25,  0.  ]])
+    >>> refpos
+    array([[[ 1. ,  2.5,  2. ],
+            [-1. , -2.5, -2. ]],
+    <BLANKLINE>
+           [[ 2. , -1. ,  2. ],
+            [-2. ,  1. , -2. ]]])
+    >>> selpos
+    array([[[ 1. ,  3.5,  0. ],
+            [-1. , -3.5,  0. ]],
+    <BLANKLINE>
+           [[ 1. ,  2.5,  2. ],
+            [-1. , -2.5, -2. ]]])
+
+    Shape of `refpos` is ``(n, 3)`` and shape of `selpos` is
+    ``(k, n, 3)``:
+
+    >>> refpos = np.array([[ 3.,  4.,  5.],
+    ...                    [ 1., -1.,  1.]])
+    >>> selpos = np.array([[[ 1.,  7., -1.],
+    ...                     [-1.,  0., -1.]],
+    ...
+    ...                    [[ 3.,  4.,  5.],
+    ...                     [ 1., -1.,  1.]]])
+    >>> selpos - refpos
+    array([[[-2.,  3., -6.],
+            [-2.,  1., -2.]],
+    <BLANKLINE>
+           [[ 0.,  0.,  0.],
+            [ 0.,  0.,  0.]]])
+    >>> rmsd = mdt.strc.rmsd(refpos, selpos)
+    >>> rmsd_expected = np.sqrt(0.5 * np.array([49 + 9, 0]))
+    >>> np.allclose(rmsd, rmsd_expected, rtol=0)
+    True
+    >>> mdt.strc.rmsd(refpos, selpos, xyz=True)
+    array([[ 4.,  5., 20.],
+           [ 0.,  0.,  0.]])
+    >>> box = np.array([5, 3, 3, 90, 90, 90])
+    >>> mdt.strc.rmsd(refpos, selpos, xyz=True, box=box)
+    array([[4. , 0.5, 0.5],
+           [0. , 0. , 0. ]])
+    >>> rmsd = mdt.strc.rmsd(refpos, selpos, weights=weights)
+    >>> rmsd_expected = np.array([4., 0.])
+    >>> np.allclose(rmsd, rmsd_expected, rtol=0)
+    True
+    >>> mdt.strc.rmsd(refpos, selpos, weights=weights, center=True)
+    array([1.56324982, 0.        ])
+    >>> mdt.strc.rmsd(
+    ...    refpos, selpos, xyz=True, center=True, inplace=True
+    ... )
+    array([[0., 1., 4.],
+           [0., 0., 0.]])
+    >>> refpos
+    array([[ 1. ,  2.5,  2. ],
+           [-1. , -2.5, -2. ]])
+    >>> selpos
+    array([[[ 1. ,  3.5,  0. ],
+            [-1. , -3.5,  0. ]],
+    <BLANKLINE>
+           [[ 1. ,  2.5,  2. ],
+            [-1. , -2.5, -2. ]]])
+    """
+    refpos = mdt.check.pos_array(refpos)
+    selpos = mdt.check.pos_array(selpos)
+    if refpos.ndim == 1:
+        n_particles = 1
+    elif refpos.ndim in (2, 3):
+        n_particles = refpos.shape[refpos.ndim - 2]
+    else:
+        # This else clause should never be entered, because this error
+        # should already be raised by `mdt.check.pos_array(refpos)`.
+        raise ValueError(
+            "The shape of 'refpos' must be either (3,) or (n, 3) or (k, n, 3)"
+            " but is {}.  This should not have happened".format(refpos.shape)
+        )
+    if (
+        (selpos.ndim == 1 and n_particles != 1)
+        or (selpos.ndim == 2 and selpos.shape[0] != n_particles)
+        or (selpos.ndim == 3 and selpos.shape[1] != n_particles)
+    ):
+        raise ValueError(
+            "'selpos' does not contain the same number of particles as"
+            " 'refpos'.  The shape of 'selpos' is {}.  The shape of 'refpos'"
+            " is {}".format(selpos.shape, refpos.shape)
+        )
+
+    if weights is not None:
+        weights = np.asarray(weights, dtype=np.float64)
+        if weights.shape != (n_particles,):
+            raise ValueError(
+                "'weights' must have shape {} but has shape"
+                " {}".format((n_particles,), weights.shape)
+            )
+        weights_sum = np.sum(weights)
+        if weights_sum == 0:
+            raise ValueError("'weights' must not sum up to zero")
+        weights /= weights_sum
+
+    if box is not None:
+        box = mdt.check.box(box)
+        if box.ndim == 2:
+            if refpos.ndim != 3:
+                raise ValueError(
+                    "box dimensions given for {} frames, but reference"
+                    " positions given for only 1 frame".format(box.shape[0])
+                )
+            if box.shape[0] != refpos.shape[0]:
+                raise ValueError(
+                    "If 'box' has 2 dimensions, box.shape[0] ({}) must match"
+                    " refpos.shape[0]"
+                    " ({})".format(box.shape[0], refpos.shape[0])
+                )
+
+    if center:
+        refcenter = mdt.strc.wcenter_pos(pos=refpos, weights=weights, box=box)
+        if refpos.ndim == 3:
+            refcenter = np.expand_dims(refcenter, axis=1)
+        selcenter = mdt.strc.wcenter_pos(pos=selpos, weights=weights, box=box)
+        if selpos.ndim == 3:
+            selcenter = np.expand_dims(selcenter, axis=1)
+        if inplace:
+            refpos -= refcenter
+            selpos -= selcenter
+        else:
+            refpos = refpos - refcenter
+            selpos = selpos - selcenter
+
+    rmsd = mdt.box.vdist(selpos, refpos, box=box)
+    rmsd **= 2
+    # The dimension of position arrays and thus of `rmsd` can be either
+    # 1, 2 or 3 (see `mdtools.check.pos_array`).  If `component` is
+    # ``True`` and `ndim` is
+    #     * 1 (single particle), the RMSD is simply the distance between
+    #       the reference and candidate particle.
+    #     * 2 (multiple particles), the RMSD is the sum over all
+    #       reference-candidate distances (``axis=0``).
+    #     * 3 (multiple frames), the RMSD is the sum over all
+    #       reference-candidate distances in each frame (``axis=1``).
+    # If `component` is ``False``, the x, y and z component must be
+    # summed up.
+    if weights is not None and rmsd.ndim > 1:
+        rmsd *= np.expand_dims(weights, axis=1)
+    if rmsd.ndim == 1:
+        if n_particles != 1:
+            raise ValueError(
+                "The shape of 'rmsd' ({}) does not match the number of"
+                " particles ({}).  You might want to check the shape of"
+                " 'refpos' ({}) and 'selpos' ({}) and which shape they"
+                " broadcast to".format(
+                    rmsd.shape, n_particles, refpos.shape, selpos.shape
+                )
+            )
+        if not xyz:
+            rmsd = np.sum(rmsd)
+    elif rmsd.ndim == 2:
+        if rmsd.shape[rmsd.ndim - 2] != n_particles:
+            raise ValueError(
+                "The shape of 'rmsd' ({}) does not match the number of"
+                " particles ({}).  You might want to check the shape of"
+                " 'refpos' ({}) and 'selpos' ({}) and which shape they"
+                " broadcast to".format(
+                    rmsd.shape, n_particles, refpos.shape, selpos.shape
+                )
+            )
+        if xyz:
+            rmsd = np.sum(rmsd, axis=rmsd.ndim - 2)
+        else:
+            rmsd = np.sum(rmsd)
+    elif rmsd.ndim == 3:
+        if rmsd.shape[rmsd.ndim - 2] != n_particles:
+            raise ValueError(
+                "The shape of 'rmsd' ({}) does not match the number of"
+                " particles ({}).  You might want to check the shape of"
+                " 'refpos' ({}) and 'selpos' ({}) and which shape they"
+                " broadcast to".format(
+                    rmsd.shape, n_particles, refpos.shape, selpos.shape
+                )
+            )
+        rmsd = np.sum(rmsd, axis=rmsd.ndim - 2)
+        if not xyz:
+            rmsd = np.sum(rmsd, axis=1)
+    else:
+        raise ValueError(
+            "The shape of 'rmsd' must be either (3,) or (n, 3) or (k, n, 3)"
+            " but is {}.  This should not have happened.  You might want to"
+            " check the shape of 'refpos' ({}) and 'selpos' ({}) and which"
+            " shape they broadcast to".format(
+                rmsd.shape, refpos.shape, selpos.shape
+            )
+        )
+    rmsd /= n_particles
+    if not xyz:
+        rmsd = np.sqrt(rmsd)
+    return rmsd

--- a/mdtools/structure.py
+++ b/mdtools/structure.py
@@ -39,176 +39,6 @@ import MDAnalysis.lib.distances as mdadist
 import mdtools as mdt
 
 
-def center(
-    ag, center='cog', pbc=False, cmp='group', make_whole=False, debug=False
-):
-    """
-    Calculate different types of centers of (compounds of) an MDAnalysis
-    :class:`~MDAnalysis.core.groups.AtomGroup`.
-
-    Parameters
-    ----------
-    ag : MDAnalysis.core.groups.AtomGroup
-        The MDAnalysis :class:`~MDAnalysis.core.groups.AtomGroup` for
-        which to calculate the center.
-    center : {'cog', 'com', 'coc'}, optional
-        Which type of center to calculate.
-
-            * ``'cog'``: Center of geometry
-            * ``'com'``: Center of mass
-            * ``'coc'``: Center of charge
-
-    pbc : bool, optional
-        If ``True`` and `cmp` is ``'group'``, move all
-        :class:`Atoms <MDAnalysis.core.groups.Atom>` in `ag` to the
-        primary unit cell **before** calculating the center.  If
-        ``True`` and `cmp` is not ``'group'``, the center of each
-        compound will be calculated without moving any
-        :class:`Atoms <MDAnalysis.core.groups.Atom>` to keep the
-        compounds intact.  Instead, the resulting position vectors will
-        be moved to the primary unit cell **after** calculating the
-        center.  Note that this option does not make compounds whole
-        that are split across periodic boundaries.  To fix broken
-        compounds before calculating their center use the option
-        `make_whole`.
-    cmp : {'group', 'segments', 'residues', 'molecules', 'fragments', \
-        'atoms'}, optional
-        The compounds of `ag` for which to calculate the center.  If
-        ``'group'``, the center of all
-        :class:`Atoms <MDAnalysis.core.groups.Atom>` in `ag` will be
-        returned as a single position vector.  If ``'atoms'``, simply
-        the positions of all atoms in `ag` will be returned (2d array).
-        Else, the center of each
-        :class:`~MDAnalysis.core.groups.Segment`,
-        :class:`~MDAnalysis.core.groups.Residue`, molecule, or
-        :attr:`fragment <MDAnalysis.core.groups.AtomGroup.fragments>`
-        contained in `ag` will be returned as an array of position
-        vectors, i.e. a 2d array.  Refer to the MDAnalysis' user guide
-        for an |explanation_of_these_terms|.  Note that in any case,
-        also if `cmp` is e.g. ``'residues'``, only the
-        :class:`Atoms <MDAnalysis.core.groups.Atom>` belonging to `ag`
-        are taken into account, even if the compound might comprise
-        additional :class:`Atoms <MDAnalysis.core.groups.Atom>` that are
-        not contained in `ag`.
-    make_whole : bool, optional
-        If ``True``, compounds whose bonds are split across periodic
-        boundaries are made whole before calculating their center.  Note
-        that all :class:`Atoms <MDAnalysis.core.groups.Atom>` in `ag`
-        are wrapped back into the primary unit cell before making
-        compounds whole to ensure that the algorithm is working
-        properly.  This means that making compounds whole in an
-        unwrapped trajectory will lead to a wrapped trajectory with
-        whole compounds (some
-        :class:`Atoms <MDAnalysis.core.groups.Atom>` may lie outside the
-        primary unit cell, but each compound's center will lie inside
-        the primary unit cell).  Note that `make_whole` has no effect if
-        `cmp` is set to ``'atoms'``.
-    debug : bool, optional
-        If ``True``, run in debug mode.
-
-    Returns
-    -------
-    centers : numpy.ndarray
-        Position of the center of each compound in `ag`.  If `cmp` was
-        set to ``'group'``, the output will be a single position vector
-        of shape ``(3,)``.  Else, the output will be a 2d array of shape
-        ``(n, 3)`` where ``n`` is the number of compounds in `ag`.
-
-    Raises
-    ------
-    RuntimeWarning :
-        If `debug` is ``True`` and the center of any compound is
-        ``nan``.
-
-    See Also
-    --------
-    :meth:`MDAnalysis.core.groups.AtomGroup.center` :
-        Weighted center of (compounds of) the group
-    :meth:`MDAnalysis.core.groups.AtomGroup.center_of_geometry` :
-        Center of geometry of (compounds of) the group
-    :meth:`MDAnalysis.core.groups.AtomGroup.center_of_mass` :
-        Center of mass of (compounds of) the group
-    :func:`mdtools.structure.wcenter` :
-        Weighted center of (compounds of) an MDAnalysis
-        :class:`~MDAnalysis.core.groups.AtomGroup`
-    :func:`mdtools.structure.wcenter_pos` :
-        Calculate the weighted center of a position array
-    :func:`mdtools.structure.coc` :
-        Center of charge of (compounds of) an MDAnalysis
-        :class:`~MDAnalysis.core.groups.AtomGroup`
-    :func:`mdtools.structure.cog` :
-        Center of geometry of (compounds of) an MDAnalysis
-        :class:`~MDAnalysis.core.groups.AtomGroup`
-    :func:`mdtools.structure.com` :
-        Center of mass of (compounds of) an MDAnalysis
-        :class:`~MDAnalysis.core.groups.AtomGroup`
-
-    Notes
-    -----
-    This function calls either :func:`mdtools.structure.coc`,
-    :func:`mdtools.structure.cog` or :func:`mdtools.structure.com`
-    depending on the value of `center`.  These functions in turn call
-    the corresponding method of the input
-    :class:`~MDAnalysis.core.groups.AtomGroup`.
-
-    .. important::
-
-        If the weights of a compound (i.e. the charges in the case of
-        ``center='coc'`` or the masses in the case of ``center='com'``)
-        sum up to zero, the coordinates of that compound's center will
-        be ``nan``!  If `debug` is set to ``True``, a warning will be
-        raised if any compound's center is ``nan``.
-
-    If `make_whole` is ``True``, all
-    :class:`Atoms <MDAnalysis.core.groups.Atom>` in `ag` are wrapped
-    back into the primary unit cell using :func:`mdtools.box.wrap`
-    before making compounds whole.  This is done to ensure that the unwrap
-    algorithm (better called "make whole" algorithm) of MDAnalysis is
-    working properly.  This means that making compounds whole in an
-    unwrapped trajectory will lead to a wrapped trajectory with whole
-    compounds (some :class:`Atoms <MDAnalysis.core.groups.Atom>` may lie
-    outside the primary unit cell, but each compound's center will lie
-    inside the primary unit cell).  `make_whole` has no effect if `cmp`
-    is set to ``'atoms'``.
-
-    .. todo::
-
-        Check if it is really necessary to wrap all
-        :class:`Atoms <MDAnalysis.core.groups.Atom>` back into the
-        primary unit cell before making compounds whole.  The currently
-        done back-wrapping is a serious problem, because it implies an
-        inplace-change of the :class:`~MDAnalysis.core.groups.Atom`
-        coordinates.
-
-    .. note:: For developers
-
-        This function is meant to be used in MDTools scripts that offer
-        the user to choose a specific compound and center for which to
-        perform the analysis (see the \\--cmp and \\--center options of
-        the :mod:`scripts.script_template`).  To get the requested
-        positions, you can simply do
-        ``pos = mdt.strc.center(ag, center=args.CENTER, cmp=args.CMP)``.
-
-    """  # noqa D301
-    if center == 'cog':
-        return mdt.strc.cog(
-            ag=ag, pbc=pbc, cmp=cmp, make_whole=make_whole, debug=debug
-        )
-    elif center == 'com':
-        return mdt.strc.com(
-            ag=ag, pbc=pbc, compound=cmp, make_whole=make_whole, debug=debug
-        )
-    elif center == 'coc':
-        return mdt.strc.coc(
-            ag=ag, pbc=pbc, cmp=cmp, make_whole=make_whole, debug=debug
-        )
-    else:
-        raise ValueError(
-            "'center' must be either 'cog', 'com' or 'coc', but you gave"
-            " {}".format(center)
-        )
-
-
 def wcenter_pos(
     pos,
     weights=None,
@@ -583,6 +413,176 @@ def wcenter(
             RuntimeWarning
         )
     return centers
+
+
+def center(
+    ag, center='cog', pbc=False, cmp='group', make_whole=False, debug=False
+):
+    """
+    Calculate different types of centers of (compounds of) an MDAnalysis
+    :class:`~MDAnalysis.core.groups.AtomGroup`.
+
+    Parameters
+    ----------
+    ag : MDAnalysis.core.groups.AtomGroup
+        The MDAnalysis :class:`~MDAnalysis.core.groups.AtomGroup` for
+        which to calculate the center.
+    center : {'cog', 'com', 'coc'}, optional
+        Which type of center to calculate.
+
+            * ``'cog'``: Center of geometry
+            * ``'com'``: Center of mass
+            * ``'coc'``: Center of charge
+
+    pbc : bool, optional
+        If ``True`` and `cmp` is ``'group'``, move all
+        :class:`Atoms <MDAnalysis.core.groups.Atom>` in `ag` to the
+        primary unit cell **before** calculating the center.  If
+        ``True`` and `cmp` is not ``'group'``, the center of each
+        compound will be calculated without moving any
+        :class:`Atoms <MDAnalysis.core.groups.Atom>` to keep the
+        compounds intact.  Instead, the resulting position vectors will
+        be moved to the primary unit cell **after** calculating the
+        center.  Note that this option does not make compounds whole
+        that are split across periodic boundaries.  To fix broken
+        compounds before calculating their center use the option
+        `make_whole`.
+    cmp : {'group', 'segments', 'residues', 'molecules', 'fragments', \
+        'atoms'}, optional
+        The compounds of `ag` for which to calculate the center.  If
+        ``'group'``, the center of all
+        :class:`Atoms <MDAnalysis.core.groups.Atom>` in `ag` will be
+        returned as a single position vector.  If ``'atoms'``, simply
+        the positions of all atoms in `ag` will be returned (2d array).
+        Else, the center of each
+        :class:`~MDAnalysis.core.groups.Segment`,
+        :class:`~MDAnalysis.core.groups.Residue`, molecule, or
+        :attr:`fragment <MDAnalysis.core.groups.AtomGroup.fragments>`
+        contained in `ag` will be returned as an array of position
+        vectors, i.e. a 2d array.  Refer to the MDAnalysis' user guide
+        for an |explanation_of_these_terms|.  Note that in any case,
+        also if `cmp` is e.g. ``'residues'``, only the
+        :class:`Atoms <MDAnalysis.core.groups.Atom>` belonging to `ag`
+        are taken into account, even if the compound might comprise
+        additional :class:`Atoms <MDAnalysis.core.groups.Atom>` that are
+        not contained in `ag`.
+    make_whole : bool, optional
+        If ``True``, compounds whose bonds are split across periodic
+        boundaries are made whole before calculating their center.  Note
+        that all :class:`Atoms <MDAnalysis.core.groups.Atom>` in `ag`
+        are wrapped back into the primary unit cell before making
+        compounds whole to ensure that the algorithm is working
+        properly.  This means that making compounds whole in an
+        unwrapped trajectory will lead to a wrapped trajectory with
+        whole compounds (some
+        :class:`Atoms <MDAnalysis.core.groups.Atom>` may lie outside the
+        primary unit cell, but each compound's center will lie inside
+        the primary unit cell).  Note that `make_whole` has no effect if
+        `cmp` is set to ``'atoms'``.
+    debug : bool, optional
+        If ``True``, run in debug mode.
+
+    Returns
+    -------
+    centers : numpy.ndarray
+        Position of the center of each compound in `ag`.  If `cmp` was
+        set to ``'group'``, the output will be a single position vector
+        of shape ``(3,)``.  Else, the output will be a 2d array of shape
+        ``(n, 3)`` where ``n`` is the number of compounds in `ag`.
+
+    Raises
+    ------
+    RuntimeWarning :
+        If `debug` is ``True`` and the center of any compound is
+        ``nan``.
+
+    See Also
+    --------
+    :meth:`MDAnalysis.core.groups.AtomGroup.center` :
+        Weighted center of (compounds of) the group
+    :meth:`MDAnalysis.core.groups.AtomGroup.center_of_geometry` :
+        Center of geometry of (compounds of) the group
+    :meth:`MDAnalysis.core.groups.AtomGroup.center_of_mass` :
+        Center of mass of (compounds of) the group
+    :func:`mdtools.structure.wcenter` :
+        Weighted center of (compounds of) an MDAnalysis
+        :class:`~MDAnalysis.core.groups.AtomGroup`
+    :func:`mdtools.structure.wcenter_pos` :
+        Calculate the weighted center of a position array
+    :func:`mdtools.structure.coc` :
+        Center of charge of (compounds of) an MDAnalysis
+        :class:`~MDAnalysis.core.groups.AtomGroup`
+    :func:`mdtools.structure.cog` :
+        Center of geometry of (compounds of) an MDAnalysis
+        :class:`~MDAnalysis.core.groups.AtomGroup`
+    :func:`mdtools.structure.com` :
+        Center of mass of (compounds of) an MDAnalysis
+        :class:`~MDAnalysis.core.groups.AtomGroup`
+
+    Notes
+    -----
+    This function calls either :func:`mdtools.structure.coc`,
+    :func:`mdtools.structure.cog` or :func:`mdtools.structure.com`
+    depending on the value of `center`.  These functions in turn call
+    the corresponding method of the input
+    :class:`~MDAnalysis.core.groups.AtomGroup`.
+
+    .. important::
+
+        If the weights of a compound (i.e. the charges in the case of
+        ``center='coc'`` or the masses in the case of ``center='com'``)
+        sum up to zero, the coordinates of that compound's center will
+        be ``nan``!  If `debug` is set to ``True``, a warning will be
+        raised if any compound's center is ``nan``.
+
+    If `make_whole` is ``True``, all
+    :class:`Atoms <MDAnalysis.core.groups.Atom>` in `ag` are wrapped
+    back into the primary unit cell using :func:`mdtools.box.wrap`
+    before making compounds whole.  This is done to ensure that the unwrap
+    algorithm (better called "make whole" algorithm) of MDAnalysis is
+    working properly.  This means that making compounds whole in an
+    unwrapped trajectory will lead to a wrapped trajectory with whole
+    compounds (some :class:`Atoms <MDAnalysis.core.groups.Atom>` may lie
+    outside the primary unit cell, but each compound's center will lie
+    inside the primary unit cell).  `make_whole` has no effect if `cmp`
+    is set to ``'atoms'``.
+
+    .. todo::
+
+        Check if it is really necessary to wrap all
+        :class:`Atoms <MDAnalysis.core.groups.Atom>` back into the
+        primary unit cell before making compounds whole.  The currently
+        done back-wrapping is a serious problem, because it implies an
+        inplace-change of the :class:`~MDAnalysis.core.groups.Atom`
+        coordinates.
+
+    .. note:: For developers
+
+        This function is meant to be used in MDTools scripts that offer
+        the user to choose a specific compound and center for which to
+        perform the analysis (see the \\--cmp and \\--center options of
+        the :mod:`scripts.script_template`).  To get the requested
+        positions, you can simply do
+        ``pos = mdt.strc.center(ag, center=args.CENTER, cmp=args.CMP)``.
+
+    """  # noqa D301
+    if center == 'cog':
+        return mdt.strc.cog(
+            ag=ag, pbc=pbc, cmp=cmp, make_whole=make_whole, debug=debug
+        )
+    elif center == 'com':
+        return mdt.strc.com(
+            ag=ag, pbc=pbc, compound=cmp, make_whole=make_whole, debug=debug
+        )
+    elif center == 'coc':
+        return mdt.strc.coc(
+            ag=ag, pbc=pbc, cmp=cmp, make_whole=make_whole, debug=debug
+        )
+    else:
+        raise ValueError(
+            "'center' must be either 'cog', 'com' or 'coc', but you gave"
+            " {}".format(center)
+        )
 
 
 def coc(ag, pbc=False, cmp='group', make_whole=False, debug=False):

--- a/mdtools/structure.py
+++ b/mdtools/structure.py
@@ -419,7 +419,7 @@ def wcenter(
     ag : MDAnalysis.core.groups.AtomGroup
         The MDAnalysis :class:`~MDAnalysis.core.groups.AtomGroup` for
         which to calculate the weighted center.
-    weights : array_like or None
+    weights : array_like or None, optional
         Weights to be used, given as a 1d array containing the weights
         for each :class:`~MDAnalysis.core.groups.Atom` in `ag`.  Weights
         are mapped to :class:`Atoms <MDAnalysis.core.groups.Atom>` by

--- a/scripts/script_template.py
+++ b/scripts/script_template.py
@@ -71,8 +71,8 @@ be called and their meaning.
 --sel       Selection string to select a group of atoms for the
             analysis.  See MDAnalysis' |selection_syntax| for possible
             choices.
---cmp       {'group', 'segments', 'residues', 'molecules', 'fragments',\
-            'atoms'}
+--cmp       {'group', 'segments', 'residues', 'molecules', \
+            'fragments', 'atoms'}
 
             The compounds of the selection group to use for the
             analysis.  Compounds can be 'group' (the entire selection

--- a/scripts/script_template.py
+++ b/scripts/script_template.py
@@ -290,8 +290,8 @@ if __name__ == "__main__":
         step=args.EVERY,
         n_frames_tot=u.trajectory.n_frames,
     )
-    first_frame_read = u.trajectory[BEGIN]
-    last_frame_read = u.trajectory[END - 1]
+    first_frame_read = u.trajectory[BEGIN].copy()
+    last_frame_read = u.trajectory[END - 1].copy()
 
     print("\n")
     print("Reading trajectory...")

--- a/scripts/structure/rmsd_vs_time.py
+++ b/scripts/structure/rmsd_vs_time.py
@@ -1,0 +1,476 @@
+#!/usr/bin/env python3
+
+# This file is part of MDTools.
+# Copyright (C) 2021, 2022  The MDTools Development Team and all
+# contributors listed in the file AUTHORS.rst
+#
+# MDTools is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.
+#
+# MDTools is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with MDTools.  If not, see <http://www.gnu.org/licenses/>.
+
+
+r"""
+Calculate the Root Mean Square Deviation (RMSD) between a reference
+frame and all other frames in the trajectory.
+
+.. todo::
+
+    * Implement a "superposition" functionality like in
+      :func:`MDAnalysis.analysis.rms.rmsd`.
+
+    * Provide an option to make broken compounds whole before
+      calculating their centers.  Currently, making compounds whole is
+      only possible by first wrapping the trajectory and then making the
+      compounds whole.  However, for calculating a time-dependent RMSD,
+      an unwrapped trajectory might be desired.
+
+Take a structure from a reference frame and calculate the RMSD to its
+configuration in all other frames in the trajectory.  This generates an
+RMSD as function of time.
+
+Options
+-------
+-f          Trajectory file.  See |supported_coordinate_formats| of
+            MDAnalysis.
+-s          Topology file.  See |supported_topology_formats| of
+            MDAnalysis.
+-o          Output filename.
+-b          First frame to read from the trajectory.  Frame numbering
+            starts at zero.  Default: ``0``.
+-e          Last frame to read from the trajectory.  This is exclusive,
+            i.e. the last frame read is actually ``END - 1``.  A value
+            of ``-1`` means to read the very last frame.  Default:
+            ``-1``.
+--every     Read every n-th frame from the trajectory.  Default: ``1``.
+--ref-frame
+            Frame from which to take the reference structure.  ``None``
+            means take the same frame as given by -b.  Default:
+            ``None``.
+--sel       Selection string to select a group of atoms for which to
+            calculate the RMSD as function of time.  See MDAnalysis'
+            |selection_syntax| for possible choices.
+--cmp       {'group', 'segments', 'residues', 'molecules', \
+            'fragments', 'atoms'}
+
+            The compounds of the selection group to use for the RMSD
+            calculation.  Compounds can be 'group' (the entire selection
+            group), 'segments', 'residues', 'molecules', 'fragments', or
+            'atoms'.  Refer to the MDAnalysis' user guide for an
+            |explanation_of_these_terms|.  Note that in any case, even
+            if ``CMP`` is e.g. 'residues', only the atoms belonging to
+            the selection group are taken into account, even if the
+            compound might comprise additional atoms that are not
+            contained in the selection group.  If COMPOUND is something
+            different than ``'atoms'``, the RMSD will be calculated
+            between the centers of the compounds as given by \--center.
+            Note that broken compounds are **not** made whole before
+            calculating their centers, so be sure to provide a
+            trajectory with whole compounds if you want to calculate the
+            RMSD between compound centers.  This decision was made,
+            because currently compounds can only be made whole when
+            wrapping the trajectory beforehand.  However, for
+            calculating a time-dependent RMSD, an unwrapped trajectory
+            might be desired.  Default: ``'atoms'``.
+--center    {'cog', 'com', 'coc'}
+
+            The center of the compounds to use for the RMSD calculation.
+
+                * ``'cog'``: Center of geometry
+                * ``'com'``: Center of mass
+                * ``'coc'``: Center of charge
+
+            Note that |mda_always_guesses_atom_masses| from the atom
+            types, even if the input file contains the masses.  Default:
+            ``'cog'``.
+--weights   {'mass', 'charge'}
+
+            Weights to use for calculating the RMSD.  If ``None``, all
+            compounds are assumed to have a weight equal to one.
+            Weights must not sum up to zero.  Thus, you cannot weight
+            atoms by charge in a charge neutral selection.  Default:
+            ``None``.
+--center-pos
+            Shift the reference and candidate positions by their
+            (weighted) center, respectively, before calculating the
+            RMSD.
+--mic       Take the minimum image convention into account when
+            calculating the RMSD.  This works also with unwrapped
+            trajectories.  The box dimensions are taken from the
+            reference frame.
+--debug     Run in :ref:`debug mode <debug-mode-label>`.
+
+See Also
+--------
+:func:`mdtools.structure.rmsd` :
+    The underlying function that is called by this script.
+
+Notes
+-----
+TODO
+
+Examples
+--------
+TODO
+"""
+
+
+__author__ = "Andreas Thum"
+
+
+# Standard libraries
+import sys
+import os
+import argparse
+from datetime import datetime, timedelta
+
+# Third party libraries
+import numpy as np
+import psutil
+
+# Local application/library specific imports
+import mdtools as mdt
+
+
+if __name__ == "__main__":
+    timer_tot = datetime.now()
+    proc = psutil.Process()
+    proc.cpu_percent()  # Initiate monitoring of CPU usage
+    parser = argparse.ArgumentParser(
+        description=(
+            "Calculate the Root Mean Square Deviation (RMSD) between a"
+            " reference frame and all other frames in the trajectory.  For"
+            " more information, refer to the documetation of this script."
+        )
+    )
+    parser.add_argument(
+        "-f",
+        dest="TRJFILE",
+        type=str,
+        required=True,
+        help=("Trajectory file."),
+    )
+    parser.add_argument(
+        "-s",
+        dest="TOPFILE",
+        type=str,
+        required=True,
+        help=("Topology file."),
+    )
+    parser.add_argument(
+        "-o",
+        dest="OUTFILE",
+        type=str,
+        required=True,
+        help=("Output filename."),
+    )
+    parser.add_argument(
+        "-b",
+        dest="BEGIN",
+        type=int,
+        required=False,
+        default=0,
+        help=(
+            "First frame to read from the trajectory.  Frame numbering starts"
+            " at zero.  Default: %(default)s."
+        ),
+    )
+    parser.add_argument(
+        "-e",
+        dest="END",
+        type=int,
+        required=False,
+        default=-1,
+        help=(
+            "Last frame to read from the trajectory (exclusive).  Default:"
+            " %(default)s."
+        ),
+    )
+    parser.add_argument(
+        "--every",
+        dest="EVERY",
+        type=int,
+        required=False,
+        default=1,
+        help=(
+            "Read every n-th frame from the trajectory.  Default: %(default)s."
+        ),
+    )
+    parser.add_argument(
+        "--ref-frame",
+        dest="REF_FRAME",
+        type=lambda val: mdt.fh.str2none_or_type(val, dtype=int),
+        required=False,
+        default=None,
+        help=(
+            "Frame from which to take the reference structure.  Default:"
+            " %(default)s."
+        ),
+    )
+    parser.add_argument(
+        "--sel",
+        dest="SEL",
+        type=str,
+        nargs="+",
+        required=True,
+        help=("Selection string."),
+    )
+    parser.add_argument(
+        "--cmp",
+        dest="CMP",
+        type=str,
+        required=False,
+        choices=(
+            "group",
+            "segments",
+            "residues",
+            "molecules",
+            "fragments",
+            "atoms",
+        ),
+        default="atoms",
+        help=(
+            "The compounds of the selection group to use for the analysis."
+            "  IMPORTANT: Compounds are not made whole before calculating"
+            " their centers!  Default: %(default)s"
+        ),
+    )
+    parser.add_argument(
+        "--center",
+        dest="CENTER",
+        type=str,
+        required=False,
+        choices=("cog", "com", "coc"),
+        default="cog",
+        help=(
+            "The center of the compounds to use for the analysis.  Default:"
+            " %(default)s"
+        ),
+    )
+    parser.add_argument(
+        "--weights",
+        dest="WEIGHTS",
+        type=str,
+        required=False,
+        choices=("mass", "charge"),
+        default=None,
+        help=(
+            "Weights to use for calculating the RMSD.  If None, all particles"
+            " are assumed to have a weight equal to one.  Default: %(default)s"
+        ),
+    )
+    parser.add_argument(
+        "--center-pos",
+        dest="CENTER_POS",
+        required=False,
+        default=False,
+        action="store_true",
+        help=(
+            "Shift the reference and candidate particles by their weighted"
+            " center, respectively, before calculating the RMSD."
+        ),
+    )
+    parser.add_argument(
+        "--mic",
+        dest="MIC",
+        required=False,
+        default=False,
+        action="store_true",
+        help=(
+            "Take the minimum image convention into account when calculating"
+            " the RMSD.  The box dimensions are taken from the reference"
+            " frame."
+        ),
+    )
+    parser.add_argument(
+        "--debug",
+        dest="DEBUG",
+        required=False,
+        default=False,
+        action="store_true",
+        help=("Run in debug mode."),
+    )
+    args = parser.parse_args()
+    print(mdt.rti.run_time_info_str())
+
+    print("\n")
+    u = mdt.select.universe(top=args.TOPFILE, trj=args.TRJFILE)
+    print("\n")
+    sel = mdt.select.atoms(ag=u, sel=" ".join(args.SEL))
+    print("\n")
+    BEGIN, END, EVERY, N_FRAMES = mdt.check.frame_slicing(
+        start=args.BEGIN,
+        stop=args.END,
+        step=args.EVERY,
+        n_frames_tot=u.trajectory.n_frames,
+    )
+    first_frame_read = u.trajectory[BEGIN].copy()
+    last_frame_read = u.trajectory[END - 1].copy()
+
+    if args.REF_FRAME is None:
+        args.REF_FRAME = BEGIN
+    if args.REF_FRAME < 0 or args.REF_FRAME >= u.trajectory.n_frames:
+        raise ValueError(
+            "--ref-frame ({}) lies outside the range of available frames ([0,"
+            " {}])".format(args.REF_FRAME, u.trajectory.n_frames)
+        )
+    ref_frame = u.trajectory[args.REF_FRAME].copy()
+    if args.MIC:
+        box = ref_frame.dimensions
+    else:
+        box = None
+    ref_pos = mdt.strc.center(
+        ag=sel,
+        center=args.CENTER,
+        pbc=False,
+        cmp=args.CMP,
+        make_whole=False,
+        debug=args.DEBUG,
+    )
+
+    if args.WEIGHTS is None:
+        weights = args.WEIGHTS
+    elif args.WEIGHTS == "mass":
+        if args.CMP == "group":
+            weights = np.sum(sel.masses)
+        elif args.CMP == "segments":
+            weights = sel.segments.masses
+        elif args.CMP == "residues":
+            weights = sel.residues.masses
+        elif args.CMP == "molecules":
+            natms_per_mol = np.unique(sel.molnums, return_counts=True)[1]
+            slices = np.cumsum(natms_per_mol[:-1], dtype=np.uint32)
+            slices = np.insert(slices, 0, 0)
+            weights = np.add.reduceat(sel.masses, slices)
+        elif args.CMP == "fragments":
+            weights = np.array([np.sum(frag.masses) for frag in sel.fragments])
+        elif args.CMP == "atoms":
+            weights = sel.masses
+        else:
+            raise ValueError("Invalide choice for --cmp ({})".format(args.CMP))
+    elif args.WEIGHTS == "charge":
+        if args.CMP == "group":
+            weights = np.sum(sel.charges)
+        elif args.CMP == "segments":
+            weights = sel.segments.charges
+        elif args.CMP == "residues":
+            weights = sel.residues.charges
+        elif args.CMP == "molecules":
+            natms_per_mol = np.unique(sel.molnums, return_counts=True)[1]
+            slices = np.cumsum(natms_per_mol[:-1], dtype=np.uint32)
+            slices = np.insert(slices, 0, 0)
+            weights = np.add.reduceat(sel.charges, slices)
+        elif args.CMP == "fragments":
+            weights = np.array(
+                [np.sum(frag.charges) for frag in sel.fragments]
+            )
+        elif args.CMP == "atoms":
+            weights = sel.charges
+        else:
+            raise ValueError("Invalide choice for --cmp ({})".format(args.CMP))
+    else:
+        raise ValueError(
+            "Invalide choice for --weights ({})".format(args.WEIGHTS)
+        )
+    if weights is not None and len(weights) != len(ref_pos):
+        raise ValueError(
+            "The number of weights ({}) does not match the number of reference"
+            " compounds ({}).  This should not have"
+            " happened".format(len(weights), len(ref_pos))
+        )
+
+    print("\n")
+    print("Reading trajectory...")
+    print("Total number of frames: {:>8d}".format(u.trajectory.n_frames))
+    print("Frames to read:         {:>8d}".format(N_FRAMES))
+    print("First frame to read:    {:>8d}".format(BEGIN))
+    print("Last frame to read:     {:>8d}".format(END - 1))
+    print("Read every n-th frame:  {:>8d}".format(EVERY))
+    print("Time first frame:       {:>12.3f} ps".format(first_frame_read.time))
+    print("Time last frame:        {:>12.3f} ps".format(last_frame_read.time))
+    print("Time step first frame:  {:>12.3f} ps".format(first_frame_read.dt))
+    print("Time step last frame:   {:>12.3f} ps".format(last_frame_read.dt))
+    print("Reference frame (RMSD): {:>8d}".format(args.REF_FRAME))
+    timer = datetime.now()
+    rmsd = np.full((N_FRAMES, 3), np.nan, dtype=np.float64)
+    trj = mdt.rti.ProgressBar(u.trajectory[BEGIN:END:EVERY])
+    for i, ts in enumerate(trj):
+        sel_pos = mdt.strc.center(
+            ag=sel,
+            center=args.CENTER,
+            pbc=False,
+            cmp=args.CMP,
+            make_whole=False,
+            debug=args.DEBUG,
+        )
+        rmsd[i] = mdt.strc.rmsd(
+            ref_pos,
+            sel_pos,
+            weights=weights,
+            center=args.CENTER_POS,
+            inplace=True,
+            xyz=True,
+            box=box,
+        )
+        # ProgressBar update:
+        trj.set_postfix_str(
+            "{:>7.2f}MiB".format(mdt.rti.mem_usage(proc)), refresh=False
+        )
+    trj.close()
+    del ref_pos, sel_pos
+    print("Elapsed time:         {}".format(datetime.now() - timer))
+    print("Current memory usage: {:.2f} MiB".format(mdt.rti.mem_usage(proc)))
+
+    print("\n")
+    print("Creating output...")
+    timer = datetime.now()
+    rmsd_tot = np.sqrt(np.sum(rmsd, axis=1))
+    times = np.array([ts.time for ts in u.trajectory[BEGIN:END:EVERY]])
+    header = (
+        "Root Mean Square Deviation (RMSD)\n"
+        "\n"
+        "Reference frame index: {}\n"
+        "Reference frame time:  {:.3f} ps\n"
+        "\n"
+        "\n"
+        "Selection: '{}'\n"
+        "Compound:  {}\n".format(
+            args.REF_FRAME, ref_frame.time, " ".join(args.SEL), args.CMP
+        )
+        + mdt.rti.ag_info_str(ag=sel)
+        + "\n"
+        "\n"
+        "\n"
+        "The columns contain:\n"
+        "  1) Time in [ps]\n"
+        "  2) RMSD in [A]\n"
+        "  3) <x^2> in [A^2] (x component of RMSD)\n"
+        "  4) <y^2> in [A^2] (y component of RMSD)\n"
+        "  5) <z^2> in [A^2] (z component of RMSD)\n"
+        "\n"
+        "{:>14d} {:>16d} {:>16d} {:>16d} {:>16d}".format(1, 2, 3, 4, 5)
+    )
+    mdt.fh.savetxt(
+        args.OUTFILE,
+        data=np.column_stack([times, rmsd_tot, rmsd]),
+        header=header,
+    )
+    print("Created {}".format(args.OUTFILE))
+    print("Elapsed time:         {}".format(datetime.now() - timer))
+    print("Current memory usage: {:.2f} MiB".format(mdt.rti.mem_usage(proc)))
+
+    print("\n")
+    print("{} done".format(os.path.basename(sys.argv[0])))
+    print("Totally elapsed time: {}".format(datetime.now() - timer_tot))
+    _cpu_time = timedelta(seconds=sum(proc.cpu_times()[:4]))
+    print("CPU time:             {}".format(_cpu_time))
+    print("CPU usage:            {:.2f} %".format(proc.cpu_percent()))
+    print("Current memory usage: {:.2f} MiB".format(mdt.rti.mem_usage(proc)))


### PR DESCRIPTION
New functionality
-----------------

* New script `rmsd_vs_time.py`: Calculate the Root Mean Square Deviation (RMSD) between a reference frame and all other frames in the trajectory.

* New functions for the core package:
    * `mdtools.box.wrap_pos`: Shift all positions of an position array into the primary unit cell.
    * `mdtools.structure.wcenter_pos`: Calculate the weighted center of an position array.
    * `mdtools.structure.rmsd`: Calculate the RMSD between two sets of positions.


Fixes
-----

* Fix `script_template.py`:
    * Change references to the first and last trajectory frames to copies.
    * Fix typo in docstring.
    
* Fix docstring of `mdtools.structure.wcenter`: Add missing "optional" keyword to the argument `weights`.


Refactoring
-----------

* Format code of `mdtools.box` with black and format all docstrings in this module.

* Refactor `mdtools.box.dist_vecs`:
    * Rename the function to `mdtools.box.vdist`.
    * Let the function take position arrays of shape ``(k, n, 3)`` and box arrays of shape ``(k, 6)``.

* Rearrange center functions in `mdtools.structure`.