### PR TITLE
Functions to locate state transitions in discretized trajectories (and arbitrary numpy ndarrays)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -93,6 +93,7 @@ jobs:
         mdtools/__init__.py \
         mdtools/_metadata.py \
         mdtools/box.py \
+        mdtools/dtrj.py \
         mdtools/file_handler.py \
         mdtools/numpy_helper_functions.py \
         mdtools/plot.py \

--- a/mdtools/check.py
+++ b/mdtools/check.py
@@ -466,7 +466,7 @@ def dtrj(dtrj, shape=None, amin=None, amax=None, dtype=None):
     If the input array has only shape ``(f,)``, it is expanded to shape
     ``(1, f)``.  Hence, the output array will always have two dimensions.
     """
-    dtrj = np.asarray(dtrj)
+    dtrj = np.asarray(dtrj, order="C")
     # Check input paramaters:
     if shape is not None and len(shape) != 2:
         raise ValueError("The length of 'shape' is {} but must be 2"

--- a/mdtools/check.py
+++ b/mdtools/check.py
@@ -469,7 +469,8 @@ def dtrj(dtrj, shape=None, amin=None, amax=None, dtype=None):
     Notes
     -----
     If the input array has only shape ``(f,)``, it is expanded to shape
-    ``(1, f)``.  Hence, the output array will always have two dimensions.
+    ``(1, f)``.  Hence, the output array will always have two
+    dimensions.
     """
     dtrj = np.asarray(dtrj, order="C")
     # Check input paramaters:

--- a/mdtools/check.py
+++ b/mdtools/check.py
@@ -412,6 +412,8 @@ def dtrj(dtrj, shape=None, amin=None, amax=None, dtype=None):
           convertet to a :class:`numpy.ndarray`.
         * Must be of shape ``(f,)`` or ``(n, f)``, where ``n`` is the
           number of compounds and ``f`` is the number of frames.
+          Transposed discrete trajectories of shape ``(f, n)`` are also
+          valid.
         * Must contain only integers or floats whose fractional part is
           zero, because the elements of a discrete trajectory are
           interpreted as the indices of the states in which a given
@@ -441,7 +443,10 @@ def dtrj(dtrj, shape=None, amin=None, amax=None, dtype=None):
     Returns
     -------
     dtrj : numpy.ndarray
-        The input array as :class:`numpy.ndarray` with two dimensions.
+        The input array as :class:`numpy.ndarray` with two dimensions
+        and in row-major order (C-style memory layout).   No copy is
+        performed if the input is already a 2-dimensional
+        :class:`numpy.ndarray` with matching order.
 
     Raises
     ------

--- a/mdtools/check.py
+++ b/mdtools/check.py
@@ -475,26 +475,28 @@ def dtrj(dtrj, shape=None, amin=None, amax=None, dtype=None):
     dtrj = np.asarray(dtrj, order="C")
     # Check input paramaters:
     if shape is not None and len(shape) != 2:
-        raise ValueError("The length of 'shape' is {} but must be 2"
-                         .format(len(shape)))
+        raise ValueError(
+            "The length of 'shape' is {} but must be 2".format(len(shape))
+        )
     # Check discrete trajectory array:
     if dtrj.ndim == 1:
         dtrj = np.expand_dims(dtrj, axis=0)
     elif dtrj.ndim > 2:
-        raise ValueError("'dtrj' has {} dimensions but must have one or"
-                         " two dimensions".format(dtrj.ndim))
+        raise ValueError(
+            "'dtrj' has {} dimensions but must have one or two"
+            " dimensions".format(dtrj.ndim)
+        )
     if np.any(np.modf(dtrj)[0] != 0):
-        raise ValueError("At least one element of 'dtrj' is not an"
-                         " integer")
+        raise ValueError(
+            "At least one element of 'dtrj' is not an integer"
+        )
     if (shape is not None or
         amin is not None or
         amax is not None or
             dtype is not None):
-        array(a=dtrj,
-              shape=shape,
-              amin=amin,
-              amax=amax,
-              dtype=dtype)
+        mdt.check.array(
+            a=dtrj, shape=shape, amin=amin, amax=amax, dtype=dtype
+        )
     return dtrj
 
 

--- a/mdtools/dtrj.py
+++ b/mdtools/dtrj.py
@@ -130,6 +130,74 @@ def locate_trans(dtrj, axis=-1, pin="end", wrap=False, tfft=False, tlft=False):
     )
 
 
+def trans_ix(dtrj, axis=-1, pin="end", wrap=False, tfft=False, tlft=False):
+    """
+    Get the frames indices of state transitions in a discrete
+    trajectory.
+
+    Parameters
+    ----------
+    dtrj : array_like
+        The discrete trajectory for which to get all frame indices where
+        its elements change.
+    axis : int
+        See :func:`mdtools.dtrj.locate_trans`.
+    pin : {"end", "start", "both"}
+        See :func:`mdtools.dtrj.locate_trans`.
+    wrap : bool, optional
+        See :func:`mdtools.dtrj.locate_trans`.
+    tfft : bool, optional
+        See :func:`mdtools.dtrj.locate_trans`.
+    tlft : bool, optional
+        See :func:`mdtools.dtrj.locate_trans`.
+
+    Returns
+    -------
+    ix_start : tuple of numpy.ndarray
+        Tuple of arrays, one for each dimension of `dtrj`, containing
+        the frame indices where a state transition will occur.  Can be
+        used to index `dtrj` and get the states right before the state
+        transition.  Is not returned if `pin` is ``"end"``.
+    ix_end : tuple of numpy.ndarray
+        Tuple of arrays, one for each dimension of `dtrj`, containing
+        the frame indices where a state transition has occurred.  Can be
+        used to index `dtrj` and get the states right after the state
+        transition.  Is not returned if `pin` is ``"start"``.
+
+    See Also
+    --------
+    :func:`mdtools.numpy_helper_functions.item_change_ix` :
+        Get the indices of item changes in arbitrary arrays
+    :func:`mdtools.dtrj.locate_trans` :
+        Locate the frames of state transitions inside a discrete
+        trajectory.
+
+    Notes
+    -----
+    This function only applies :func:`numpy.nonzero` to the output of
+    :func:`mdtools.dtrj.locate_trans`.
+
+    Examples
+    --------
+    >>> dtrj = np.array([[1, 2, 2, 3, 3, 3],
+    ...                  [2, 2, 3, 3, 3, 1],
+    ...                  [3, 3, 3, 1, 2, 2],
+    ...                  [1, 3, 3, 3, 2, 2]])
+    >>> start, end = mdt.dtrj.trans_ix(dtrj, pin="both")
+    >>> start
+    (array([0, 0, 1, 1, 2, 2, 3, 3]), array([0, 2, 1, 4, 2, 3, 0, 3]))
+    >>> end
+    (array([0, 0, 1, 1, 2, 2, 3, 3]), array([1, 3, 2, 5, 3, 4, 1, 4]))
+    """
+    trans = mdt.dtrj.locate_trans(
+        dtrj=dtrj, axis=axis, pin=pin, wrap=wrap, tfft=tfft, tlft=tlft
+    )
+    if pin == "both":
+        return tuple(np.nonzero(tr) for tr in trans)
+    else:
+        return np.nonzero(trans)
+
+
 def trans_per_state(dtrj, axis=-1):
     """
     Count the number of transitions leading into or out of a given state.

--- a/mdtools/dtrj.py
+++ b/mdtools/dtrj.py
@@ -21,8 +21,7 @@ Functions dealing with discrete trajectories.
 
 Discrete trajectories must be stored in arrays.  Arrays that serve as
 discrete trajectory must meet the requirements listed in
-:func:`mdtools.check.dtrj`.  If a function in this module deviates from
-these requirements, it will be cleary stated.
+:func:`mdtools.check.dtrj`.
 """
 
 

--- a/mdtools/dtrj.py
+++ b/mdtools/dtrj.py
@@ -95,6 +95,9 @@ def locate_trans(dtrj, axis=-1, pin="end", wrap=False, tfft=False, tlft=False):
     --------
     :func:`mdtools.numpy_helper_functions.locate_item_change`:
         Locate the positions of item changes in arbitrary arrays
+    :func:`mdtools.dtrj.trans_ix` :
+        Get the frames indices of state transitions in a discrete
+        trajectory
 
     Notes
     -----
@@ -102,9 +105,11 @@ def locate_trans(dtrj, axis=-1, pin="end", wrap=False, tfft=False, tlft=False):
     trajectory using :func:`mdtools.check.dtrj` and then calls
     :func:`mdtools.numpy_helper_functions.locate_item_change`.
 
-    To get the indices (i.e. frames) of the state transitions for each
-    compound, apply :func:`numpy.nonzero` to the output arrays of this
-    function.
+    To get the frame indices of the state transitions for each compound,
+    apply :func:`numpy.nonzero` to the output array(s) of this function.
+    If you are only interested in the frame indices but not in the
+    boolean arrays returned by this function, you can use
+    :func:`mdtools.dtrj.trans_ix` instead.
 
     Examples
     --------

--- a/mdtools/numpy_helper_functions.py
+++ b/mdtools/numpy_helper_functions.py
@@ -1045,6 +1045,8 @@ def locate_item_change(
     --------
     :func:`mdtools.numpy_helper_functions.item_change_ix` :
         Get the indices of item changes in an array
+    :func:`mdtools.dtrj.locate_trans` :
+        Same function but specifically for discrete trajectories
 
     Notes
     -----

--- a/mdtools/numpy_helper_functions.py
+++ b/mdtools/numpy_helper_functions.py
@@ -712,14 +712,17 @@ def ix_of_item_change_1d(a):
     Get the indices of a 1-dimensional array where its elements change.
 
     .. deprecated:: 0.0.0.dev0
-       :func:`mdtools.numpy_helper_functions.ix_of_item_change_1d` might
-       be removed in a future release.  It is replaced by
-       :func:`mdtools.numpy_helper_functions.ix_of_item_change`, because
-       this function works for arrays with arbitrary dimensions and
-       provides additional functionality.
+        :func:`mdtools.numpy_helper_functions.ix_of_item_change_1d`
+        might be removed in a future release.  It is replaced by
+        :func:`mdtools.numpy_helper_functions.ix_of_item_change`,
+        because this function works for arrays with arbitrary dimensions
+        and provides additional functionality.
+        :func:`mdtools.numpy_helper_functions.ix_of_item_change` with
+        `prepend_zero` set to ``True`` is equivalent to
+        :func:`mdtools.numpy_helper_functions.ix_of_item_change_1d`.
 
     .. todo::
-       Check for scripts using this function before removing it.
+        Check for scripts using this function before removing it.
 
     Parameters
     ----------

--- a/mdtools/numpy_helper_functions.py
+++ b/mdtools/numpy_helper_functions.py
@@ -1437,6 +1437,491 @@ def locate_item_change(
     return item_change_before, item_change_after
 
 
+def item_change_ix(
+    a, axis=-1, pin="after", wrap=False, tfic=False, tlic=False
+):
+    """
+    Get the indices of item changes in an array.
+
+    Parameters
+    ----------
+    a : array_like
+        Array for which to get all indices where its elements change.
+    axis : int, optional
+        See :func:`mdtools.numpy_helper_functions.locate_item_change`.
+    pin : {"after", "before", "both"}
+        See :func:`mdtools.numpy_helper_functions.locate_item_change`.
+    wrap : bool, optional
+        See :func:`mdtools.numpy_helper_functions.locate_item_change`.
+    tfic : bool, optional
+        See :func:`mdtools.numpy_helper_functions.locate_item_change`.
+    tlic : bool, optional
+        See :func:`mdtools.numpy_helper_functions.locate_item_change`.
+
+    Returns
+    -------
+    ix_before : tuple of numpy.ndarray
+        Tuple of arrays, one for each dimension of `a`, containing the
+        indices where the elements of `a` will change.  Can be used to
+        index `a` and get its values right before the item change.  Is
+        not returned if `pin` is ``"after"``.
+    ix_after : tuple of numpy.ndarray
+        Tuple of arrays, one for each dimension of `a`, containing the
+        indices where the elements of `a` have changed.  Can be used to
+        index `a` and get its values right after the item change.  Is
+        not returned if `pin` is ``"before"``.
+
+    See Also
+    --------
+    :func:`mdtools.numpy_helper_functions.locate_item_change` :
+        Locate the positions of item changes in an array
+
+    Notes
+    -----
+    This function only applies :func:`numpy.nonzero` to the output of
+    :func:`mdtools.numpy_helper_functions.locate_item_change`.
+
+    Examples
+    --------
+    >>> a = np.array([1, 2, 2, 3, 3, 3])
+    >>> before, after = mdt.nph.item_change_ix(a, pin="both")
+    >>> before
+    (array([0, 2]),)
+    >>> after
+    (array([1, 3]),)
+    >>> before_wrap, after_wrap = mdt.nph.item_change_ix(
+    ...     a, pin="both", wrap=True
+    ... )
+    >>> before_wrap
+    (array([0, 2, 5]),)
+    >>> after_wrap
+    (array([0, 1, 3]),)
+    >>> before_tfic, after_tfic = mdt.nph.item_change_ix(
+    ...     a, pin="both", tfic=True
+    ... )
+    >>> before_tfic
+    (array([0, 2]),)
+    >>> after_tfic
+    (array([0, 1, 3]),)
+    >>> before_tlic, after_tlic = mdt.nph.item_change_ix(
+    ...     a, pin="both", tlic=True
+    ... )
+    >>> before_tlic
+    (array([0, 2, 5]),)
+    >>> after_tlic
+    (array([1, 3]),)
+    >>> before_tfic_tlic, after_tfic_tlic = mdt.nph.item_change_ix(
+    ...     a, pin="both", tfic=True, tlic=True
+    ... )
+    >>> before_tfic_tlic
+    (array([0, 2, 5]),)
+    >>> after_tfic_tlic
+    (array([0, 1, 3]),)
+
+    >>> a = np.array([1, 2, 2, 3, 3, 3, 1])
+    >>> before, after = mdt.nph.item_change_ix(a, pin="both")
+    >>> before
+    (array([0, 2, 5]),)
+    >>> after
+    (array([1, 3, 6]),)
+    >>> before_wrap, after_wrap = mdt.nph.item_change_ix(
+    ...     a, pin="both", wrap=True
+    ... )
+    >>> before_wrap
+    (array([0, 2, 5]),)
+    >>> after_wrap
+    (array([1, 3, 6]),)
+    >>> before_tfic_tlic, after_tfic_tlic = mdt.nph.item_change_ix(
+    ...     a, pin="both", tfic=True, tlic=True
+    ... )
+    >>> before_tfic_tlic
+    (array([0, 2, 5, 6]),)
+    >>> after_tfic_tlic
+    (array([0, 1, 3, 6]),)
+
+    2-dimensional example:
+
+    >>> a = np.array([[1, 3, 3, 3],
+    ...               [3, 1, 3, 3],
+    ...               [3, 3, 1, 3]])
+    >>> ax = 0
+    >>> before, after = mdt.nph.item_change_ix(a, axis=ax, pin="both")
+    >>> before
+    (array([0, 0, 1, 1]), array([0, 1, 1, 2]))
+    >>> after
+    (array([1, 1, 2, 2]), array([0, 1, 1, 2]))
+    >>> before_wrap, after_wrap = mdt.nph.item_change_ix(
+    ...     a, axis=ax, pin="both", wrap=True
+    ... )
+    >>> before_wrap
+    (array([0, 0, 1, 1, 2, 2]), array([0, 1, 1, 2, 0, 2]))
+    >>> after_wrap
+    (array([0, 0, 1, 1, 2, 2]), array([0, 2, 0, 1, 1, 2]))
+    >>> before_tfic_tlic, after_tfic_tlic = mdt.nph.item_change_ix(
+    ...     a, axis=ax, pin="both", tfic=True, tlic=True
+    ... )
+    >>> before_tfic_tlic
+    (array([0, 0, 1, 1, 2, 2, 2, 2]), array([0, 1, 1, 2, 0, 1, 2, 3]))
+    >>> after_tfic_tlic
+    (array([0, 0, 0, 0, 1, 1, 2, 2]), array([0, 1, 2, 3, 0, 1, 1, 2]))
+
+    >>> ax = 1
+    >>> before, after = mdt.nph.item_change_ix(a, axis=ax, pin="both")
+    >>> before
+    (array([0, 1, 1, 2, 2]), array([0, 0, 1, 1, 2]))
+    >>> after
+    (array([0, 1, 1, 2, 2]), array([1, 1, 2, 2, 3]))
+    >>> before_wrap, after_wrap = mdt.nph.item_change_ix(
+    ...     a, axis=ax, pin="both", wrap=True
+    ... )
+    >>> before_wrap
+    (array([0, 0, 1, 1, 2, 2]), array([0, 3, 0, 1, 1, 2]))
+    >>> after_wrap
+    (array([0, 0, 1, 1, 2, 2]), array([0, 1, 1, 2, 2, 3]))
+    >>> before_tfic_tlic, after_tfic_tlic = mdt.nph.item_change_ix(
+    ...     a, axis=ax, pin="both", tfic=True, tlic=True
+    ... )
+    >>> before_tfic_tlic
+    (array([0, 0, 1, 1, 1, 2, 2, 2]), array([0, 3, 0, 1, 3, 1, 2, 3]))
+    >>> after_tfic_tlic
+    (array([0, 0, 1, 1, 1, 2, 2, 2]), array([0, 1, 0, 1, 2, 0, 2, 3]))
+
+    3-dimensional expample:
+
+    >>> a = np.array([[[1, 2, 2],
+    ...                [2, 2, 1]],
+    ...
+    ...               [[2, 2, 1],
+    ...                [1, 2, 2]]])
+    >>> ax = 0
+    >>> before, after = mdt.nph.item_change_ix(a, axis=ax, pin="both")
+    >>> before
+    (array([0, 0, 0, 0]), array([0, 0, 1, 1]), array([0, 2, 0, 2]))
+    >>> after
+    (array([1, 1, 1, 1]), array([0, 0, 1, 1]), array([0, 2, 0, 2]))
+    >>> before_wrap, after_wrap = mdt.nph.item_change_ix(
+    ...     a, axis=ax, pin="both", wrap=True
+    ... )
+    >>> before_wrap
+    (array([0, 0, 0, 0, 1, 1, 1, 1]), \
+array([0, 0, 1, 1, 0, 0, 1, 1]), \
+array([0, 2, 0, 2, 0, 2, 0, 2]))
+    >>> after_wrap
+    (array([0, 0, 0, 0, 1, 1, 1, 1]), \
+array([0, 0, 1, 1, 0, 0, 1, 1]), \
+array([0, 2, 0, 2, 0, 2, 0, 2]))
+    >>> before_tfic_tlic, after_tfic_tlic = mdt.nph.item_change_ix(
+    ...     a, axis=ax, pin="both", tfic=True, tlic=True
+    ... )
+    >>> before_tfic_tlic
+    (array([0, 0, 0, 0, 1, 1, 1, 1, 1, 1]), \
+array([0, 0, 1, 1, 0, 0, 0, 1, 1, 1]), \
+array([0, 2, 0, 2, 0, 1, 2, 0, 1, 2]))
+    >>> after_tfic_tlic
+    (array([0, 0, 0, 0, 0, 0, 1, 1, 1, 1]), \
+array([0, 0, 0, 1, 1, 1, 0, 0, 1, 1]), \
+array([0, 1, 2, 0, 1, 2, 0, 2, 0, 2]))
+
+    >>> ax = 1
+    >>> before, after = mdt.nph.item_change_ix(a, axis=ax, pin="both")
+    >>> before
+    (array([0, 0, 1, 1]), array([0, 0, 0, 0]), array([0, 2, 0, 2]))
+    >>> after
+    (array([0, 0, 1, 1]), array([1, 1, 1, 1]), array([0, 2, 0, 2]))
+    >>> before_wrap, after_wrap = mdt.nph.item_change_ix(
+    ...     a, axis=ax, pin="both", wrap=True
+    ... )
+    >>> before_wrap
+    (array([0, 0, 0, 0, 1, 1, 1, 1]), \
+array([0, 0, 1, 1, 0, 0, 1, 1]), \
+array([0, 2, 0, 2, 0, 2, 0, 2]))
+    >>> after_wrap
+    (array([0, 0, 0, 0, 1, 1, 1, 1]), \
+array([0, 0, 1, 1, 0, 0, 1, 1]), \
+array([0, 2, 0, 2, 0, 2, 0, 2]))
+    >>> before_tfic_tlic, after_tfic_tlic = mdt.nph.item_change_ix(
+    ...     a, axis=ax, pin="both", tfic=True, tlic=True
+    ... )
+    >>> before_tfic_tlic
+    (array([0, 0, 0, 0, 0, 1, 1, 1, 1, 1]), \
+array([0, 0, 1, 1, 1, 0, 0, 1, 1, 1]), \
+array([0, 2, 0, 1, 2, 0, 2, 0, 1, 2]))
+    >>> after_tfic_tlic
+    (array([0, 0, 0, 0, 0, 1, 1, 1, 1, 1]), \
+array([0, 0, 0, 1, 1, 0, 0, 0, 1, 1]), \
+array([0, 1, 2, 0, 2, 0, 1, 2, 0, 2]))
+
+    >>> ax = 2
+    >>> before, after = mdt.nph.item_change_ix(a, axis=ax, pin="both")
+    >>> before
+    (array([0, 0, 1, 1]), array([0, 1, 0, 1]), array([0, 1, 1, 0]))
+    >>> after
+    (array([0, 0, 1, 1]), array([0, 1, 0, 1]), array([1, 2, 2, 1]))
+    >>> before_wrap, after_wrap = mdt.nph.item_change_ix(
+    ...     a, axis=ax, pin="both", wrap=True
+    ... )
+    >>> before_wrap
+    (array([0, 0, 0, 0, 1, 1, 1, 1]), \
+array([0, 0, 1, 1, 0, 0, 1, 1]), \
+array([0, 2, 1, 2, 1, 2, 0, 2]))
+    >>> after_wrap
+    (array([0, 0, 0, 0, 1, 1, 1, 1]), \
+array([0, 0, 1, 1, 0, 0, 1, 1]), \
+array([0, 1, 0, 2, 0, 2, 0, 1]))
+    >>> before_tfic_tlic, after_tfic_tlic = mdt.nph.item_change_ix(
+    ...     a, axis=ax, pin="both", tfic=True, tlic=True
+    ... )
+    >>> before_tfic_tlic
+    (array([0, 0, 0, 0, 1, 1, 1, 1]), \
+array([0, 0, 1, 1, 0, 0, 1, 1]), \
+array([0, 2, 1, 2, 1, 2, 0, 2]))
+    >>> after_tfic_tlic
+    (array([0, 0, 0, 0, 1, 1, 1, 1]), \
+array([0, 0, 1, 1, 0, 0, 1, 1]), \
+array([0, 1, 0, 2, 0, 2, 0, 1]))
+
+    Edge cases:
+
+    >>> a = np.array([[1, 2, 2]])
+    >>> ax = 0
+    >>> before, after = mdt.nph.item_change_ix(a, axis=ax, pin="both")
+    >>> before
+    (array([], dtype=int64), array([], dtype=int64))
+    >>> after
+    (array([], dtype=int64), array([], dtype=int64))
+    >>> before_wrap, after_wrap = mdt.nph.item_change_ix(
+    ...     a, axis=ax, pin="both", wrap=True
+    ... )
+    >>> before_wrap
+    (array([], dtype=int64), array([], dtype=int64))
+    >>> after_wrap
+    (array([], dtype=int64), array([], dtype=int64))
+    >>> before_tfic_tlic, after_tfic_tlic = mdt.nph.item_change_ix(
+    ...     a, axis=ax, pin="both", tfic=True, tlic=True
+    ... )
+    >>> before_tfic_tlic
+    (array([0, 0, 0]), array([0, 1, 2]))
+    >>> after_tfic_tlic
+    (array([0, 0, 0]), array([0, 1, 2]))
+    >>> ax = 1
+    >>> before, after = mdt.nph.item_change_ix(a, axis=ax, pin="both")
+    >>> before
+    (array([0]), array([0]))
+    >>> after
+    (array([0]), array([1]))
+    >>> before_wrap, after_wrap = mdt.nph.item_change_ix(
+    ...     a, axis=ax, pin="both", wrap=True
+    ... )
+    >>> before_wrap
+    (array([0, 0]), array([0, 2]))
+    >>> after_wrap
+    (array([0, 0]), array([0, 1]))
+    >>> before_tfic_tlic, after_tfic_tlic = mdt.nph.item_change_ix(
+    ...     a, axis=ax, pin="both", tfic=True, tlic=True
+    ... )
+    >>> before_tfic_tlic
+    (array([0, 0]), array([0, 2]))
+    >>> after_tfic_tlic
+    (array([0, 0]), array([0, 1]))
+
+    >>> a = np.array([]).reshape(2,0)
+    >>> ax = 0
+    >>> before, after = mdt.nph.item_change_ix(a, axis=ax, pin="both")
+    >>> before
+    (array([], dtype=int64), array([], dtype=int64))
+    >>> after
+    (array([], dtype=int64), array([], dtype=int64))
+    >>> before_wrap, after_wrap = mdt.nph.item_change_ix(
+    ...     a, axis=ax, pin="both", wrap=True
+    ... )
+    >>> before_wrap
+    (array([], dtype=int64), array([], dtype=int64))
+    >>> after_wrap
+    (array([], dtype=int64), array([], dtype=int64))
+    >>> before_tfic_tlic, after_tfic_tlic = mdt.nph.item_change_ix(
+    ...     a, axis=ax, pin="both", tfic=True, tlic=True
+    ... )
+    >>> before_tfic_tlic
+    (array([], dtype=int64), array([], dtype=int64))
+    >>> after_tfic_tlic
+    (array([], dtype=int64), array([], dtype=int64))
+    >>> ax = 1
+    >>> before, after = mdt.nph.item_change_ix(a, axis=ax, pin="both")
+    >>> before
+    (array([], dtype=int64), array([], dtype=int64))
+    >>> after
+    (array([], dtype=int64), array([], dtype=int64))
+    >>> before_wrap, after_wrap = mdt.nph.item_change_ix(
+    ...     a, axis=ax, pin="both", wrap=True
+    ... )
+    >>> before_wrap
+    (array([], dtype=int64), array([], dtype=int64))
+    >>> after_wrap
+    (array([], dtype=int64), array([], dtype=int64))
+    >>> before_tfic_tlic, after_tfic_tlic = mdt.nph.item_change_ix(
+    ...     a, axis=ax, pin="both", tfic=True, tlic=True
+    ... )
+    >>> before_tfic_tlic
+    (array([], dtype=int64), array([], dtype=int64))
+    >>> after_tfic_tlic
+    (array([], dtype=int64), array([], dtype=int64))
+
+    >>> a = np.array(0)
+    >>> mdt.nph.item_change_ix(a, pin="both")
+    Traceback (most recent call last):
+    ...
+    ValueError: The input array must be at least one dimensional
+
+    >>> mdt.nph.item_change_ix(a, pin="both", wrap=True, tfic=True)
+    Traceback (most recent call last):
+    ...
+    ValueError: 'wrap' must not be used together with 'tfic' of 'tlic'
+
+    Examples from
+    :func:`mdtools.numpy_helper_functions.ix_of_item_change` mapped to
+    :func:`mdtools.numpy_helper_functions.item_change_ix`:
+
+    >>> a = np.arange(3)
+    >>> a
+    array([0, 1, 2])
+    >>> mdt.nph.item_change_ix(a, pin="after")
+    (array([1, 2]),)
+    >>> mdt.nph.item_change_ix(a, pin="after", wrap=True)
+    (array([0, 1, 2]),)
+    >>> ix = mdt.nph.item_change_ix(a, pin="after", tfic=True)
+    >>> ix
+    (array([0, 1, 2]),)
+    >>> a[ix]
+    array([0, 1, 2])
+
+    >>> b = np.array([1, 2, 2, 3, 3, 3, 1])
+    >>> mdt.nph.item_change_ix(b, pin="after")
+    (array([1, 3, 6]),)
+    >>> mdt.nph.item_change_ix(b, pin="after", wrap=True)
+    (array([1, 3, 6]),)
+    >>> ix = mdt.nph.item_change_ix(b, pin="after", tfic=True)
+    >>> ix
+    (array([0, 1, 3, 6]),)
+    >>> b[ix]
+    array([1, 2, 3, 1])
+
+    >>> c = np.ones(3)
+    >>> ix = mdt.nph.item_change_ix(c, pin="after")
+    >>> ix
+    (array([], dtype=int64),)
+    >>> c[ix]
+    array([], dtype=float64)
+    >>> mdt.nph.item_change_ix(c, pin="after", wrap=True)
+    (array([], dtype=int64),)
+    >>> mdt.nph.item_change_ix(c, pin="after", tfic=True)
+    (array([0]),)
+
+    2-dimensional example:
+
+    >>> d = np.array([[1, 3, 3, 3],
+    ...               [3, 1, 3, 3],
+    ...               [3, 3, 1, 3]])
+    >>> ax = 0
+    >>> mdt.nph.item_change_ix(d, axis=ax, pin="after")
+    (array([1, 1, 2, 2]), array([0, 1, 1, 2]))
+    >>> mdt.nph.item_change_ix(d, axis=ax, pin="after", wrap=True)
+    (array([0, 0, 1, 1, 2, 2]), array([0, 2, 0, 1, 1, 2]))
+    >>> ix = mdt.nph.item_change_ix(d, axis=ax, pin="after", tfic=True)
+    >>> ix
+    (array([0, 0, 0, 0, 1, 1, 2, 2]), array([0, 1, 2, 3, 0, 1, 1, 2]))
+    >>> d[ix]
+    array([1, 3, 3, 3, 3, 1, 3, 1])
+
+    >>> ax = 1
+    >>> mdt.nph.item_change_ix(d, axis=ax, pin="after")
+    (array([0, 1, 1, 2, 2]), array([1, 1, 2, 2, 3]))
+    >>> mdt.nph.item_change_ix(d, axis=ax, pin="after", wrap=True)
+    (array([0, 0, 1, 1, 2, 2]), array([0, 1, 1, 2, 2, 3]))
+    >>> mdt.nph.item_change_ix(d, axis=ax, pin="after", tfic=True)
+    (array([0, 0, 1, 1, 1, 2, 2, 2]), array([0, 1, 0, 1, 2, 0, 2, 3]))
+
+    3-dimensional expample:
+
+    >>> e = np.array([[[1, 2, 2],
+    ...                [2, 2, 1]],
+    ...
+    ...               [[2, 2, 1],
+    ...                [1, 2, 2]]])
+    >>> ax = 0
+    >>> mdt.nph.item_change_ix(e, axis=ax, pin="after")
+    (array([1, 1, 1, 1]), array([0, 0, 1, 1]), array([0, 2, 0, 2]))
+    >>> mdt.nph.item_change_ix(e, axis=ax, pin="after", wrap=True)
+    (array([0, 0, 0, 0, 1, 1, 1, 1]), \
+array([0, 0, 1, 1, 0, 0, 1, 1]), \
+array([0, 2, 0, 2, 0, 2, 0, 2]))
+    >>> ix = mdt.nph.item_change_ix(e, axis=ax, pin="after", tfic=True)
+    >>> ix
+    (array([0, 0, 0, 0, 0, 0, 1, 1, 1, 1]), \
+array([0, 0, 0, 1, 1, 1, 0, 0, 1, 1]), \
+array([0, 1, 2, 0, 1, 2, 0, 2, 0, 2]))
+    >>> e[ix]
+    array([1, 2, 2, 2, 2, 1, 2, 1, 1, 2])
+
+    >>> ax = 1
+    >>> mdt.nph.item_change_ix(e, axis=ax, pin="after")
+    (array([0, 0, 1, 1]), array([1, 1, 1, 1]), array([0, 2, 0, 2]))
+    >>> mdt.nph.item_change_ix(e, axis=ax, pin="after", wrap=True)
+    (array([0, 0, 0, 0, 1, 1, 1, 1]), \
+array([0, 0, 1, 1, 0, 0, 1, 1]), \
+array([0, 2, 0, 2, 0, 2, 0, 2]))
+    >>> mdt.nph.item_change_ix(e, axis=ax, pin="after", tfic=True)
+    (array([0, 0, 0, 0, 0, 1, 1, 1, 1, 1]), \
+array([0, 0, 0, 1, 1, 0, 0, 0, 1, 1]), \
+array([0, 1, 2, 0, 2, 0, 1, 2, 0, 2]))
+
+    >>> ax = 2
+    >>> mdt.nph.item_change_ix(e, axis=ax, pin="after")
+    (array([0, 0, 1, 1]), array([0, 1, 0, 1]), array([1, 2, 2, 1]))
+    >>> mdt.nph.item_change_ix(e, axis=ax, pin="after", wrap=True)
+    (array([0, 0, 0, 0, 1, 1, 1, 1]), \
+array([0, 0, 1, 1, 0, 0, 1, 1]), \
+array([0, 1, 0, 2, 0, 2, 0, 1]))
+    >>> mdt.nph.item_change_ix(e, axis=ax, pin="after", tfic=True)
+    (array([0, 0, 0, 0, 1, 1, 1, 1]), \
+array([0, 0, 1, 1, 0, 0, 1, 1]), \
+array([0, 1, 0, 2, 0, 2, 0, 1]))
+
+    Edge cases:
+
+    >>> x = np.array([1])
+    >>> mdt.nph.item_change_ix(x, pin="after")
+    (array([], dtype=int64),)
+    >>> mdt.nph.item_change_ix(x, pin="after", wrap=True)
+    (array([], dtype=int64),)
+    >>> mdt.nph.item_change_ix(x, pin="after", tfic=True)
+    (array([0]),)
+
+    >>> x = np.array([])
+    >>> mdt.nph.item_change_ix(x, pin="after")
+    (array([], dtype=int64),)
+    >>> mdt.nph.item_change_ix(x, pin="after", wrap=True)
+    (array([], dtype=int64),)
+    >>> ix = mdt.nph.item_change_ix(x, pin="after", tfic=True)
+    >>> ix
+    (array([], dtype=int64),)
+    >>> x[ix]
+    array([], dtype=float64)
+
+    >>> x = np.array(0)
+    >>> mdt.nph.item_change_ix(x, pin="after")
+    Traceback (most recent call last):
+    ...
+    ValueError: The dimension of a must be greater than zero
+    """
+    item_changes = mdt.nph.locate_item_change(
+        a=a, axis=axis, pin=pin, wrap=wrap, tfic=tfic, tlic=tlic
+    )
+    if pin == "both":
+        return tuple(np.nonzero(ic) for ic in item_changes)
+    else:
+        return np.nonzero(item_changes)
+
+
 def argmin_last(a, axis=None, out=None):
     """
     Get the indices of the minimum values along an axis.

--- a/mdtools/numpy_helper_functions.py
+++ b/mdtools/numpy_helper_functions.py
@@ -902,10 +902,14 @@ def ix_of_item_change(a, axis=-1, wrap=False, prepend_zero=False):
     >>> mdt.nph.ix_of_item_change(e, axis=ax)
     (array([1, 1, 1, 1]), array([0, 0, 1, 1]), array([0, 2, 0, 2]))
     >>> mdt.nph.ix_of_item_change(e, axis=ax, wrap=True)
-    (array([0, 0, 0, 0, 1, 1, 1, 1]), array([0, 0, 1, 1, 0, 0, 1, 1]), array([0, 2, 0, 2, 0, 2, 0, 2]))
+    (array([0, 0, 0, 0, 1, 1, 1, 1]), \
+array([0, 0, 1, 1, 0, 0, 1, 1]), \
+array([0, 2, 0, 2, 0, 2, 0, 2]))
     >>> ix = mdt.nph.ix_of_item_change(e, axis=ax, prepend_zero=True)
     >>> ix
-    (array([0, 0, 0, 0, 0, 0, 1, 1, 1, 1]), array([0, 0, 0, 1, 1, 1, 0, 0, 1, 1]), array([0, 1, 2, 0, 1, 2, 0, 2, 0, 2]))
+    (array([0, 0, 0, 0, 0, 0, 1, 1, 1, 1]), \
+array([0, 0, 0, 1, 1, 1, 0, 0, 1, 1]), \
+array([0, 1, 2, 0, 1, 2, 0, 2, 0, 2]))
     >>> e[ix]
     array([1, 2, 2, 2, 2, 1, 2, 1, 1, 2])
 
@@ -913,17 +917,25 @@ def ix_of_item_change(a, axis=-1, wrap=False, prepend_zero=False):
     >>> mdt.nph.ix_of_item_change(e, axis=ax)
     (array([0, 0, 1, 1]), array([1, 1, 1, 1]), array([0, 2, 0, 2]))
     >>> mdt.nph.ix_of_item_change(e, axis=ax, wrap=True)
-    (array([0, 0, 0, 0, 1, 1, 1, 1]), array([0, 0, 1, 1, 0, 0, 1, 1]), array([0, 2, 0, 2, 0, 2, 0, 2]))
+    (array([0, 0, 0, 0, 1, 1, 1, 1]), \
+array([0, 0, 1, 1, 0, 0, 1, 1]), \
+array([0, 2, 0, 2, 0, 2, 0, 2]))
     >>> mdt.nph.ix_of_item_change(e, axis=ax, prepend_zero=True)
-    (array([0, 0, 0, 0, 0, 1, 1, 1, 1, 1]), array([0, 0, 0, 1, 1, 0, 0, 0, 1, 1]), array([0, 1, 2, 0, 2, 0, 1, 2, 0, 2]))
+    (array([0, 0, 0, 0, 0, 1, 1, 1, 1, 1]), \
+array([0, 0, 0, 1, 1, 0, 0, 0, 1, 1]), \
+array([0, 1, 2, 0, 2, 0, 1, 2, 0, 2]))
 
     >>> ax = 2
     >>> mdt.nph.ix_of_item_change(e, axis=ax)
     (array([0, 0, 1, 1]), array([0, 1, 0, 1]), array([1, 2, 2, 1]))
     >>> mdt.nph.ix_of_item_change(e, axis=ax, wrap=True)
-    (array([0, 0, 0, 0, 1, 1, 1, 1]), array([0, 0, 1, 1, 0, 0, 1, 1]), array([0, 1, 0, 2, 0, 2, 0, 1]))
+    (array([0, 0, 0, 0, 1, 1, 1, 1]), \
+array([0, 0, 1, 1, 0, 0, 1, 1]), \
+array([0, 1, 0, 2, 0, 2, 0, 1]))
     >>> mdt.nph.ix_of_item_change(e, axis=ax, prepend_zero=True)
-    (array([0, 0, 0, 0, 1, 1, 1, 1]), array([0, 0, 1, 1, 0, 0, 1, 1]), array([0, 1, 0, 2, 0, 2, 0, 1]))
+    (array([0, 0, 0, 0, 1, 1, 1, 1]), \
+array([0, 0, 1, 1, 0, 0, 1, 1]), \
+array([0, 1, 0, 2, 0, 2, 0, 1]))
 
     Edge cases:
 
@@ -951,7 +963,7 @@ def ix_of_item_change(a, axis=-1, wrap=False, prepend_zero=False):
     Traceback (most recent call last):
     ...
     ValueError: The dimension of a must be greater than zero
-    """  # noqa: W505,E501
+    """
     if wrap and prepend_zero:
         raise ValueError("wrap and prepend_zero must not be used together")
     a = np.asarray(a)

--- a/mdtools/numpy_helper_functions.py
+++ b/mdtools/numpy_helper_functions.py
@@ -1511,6 +1511,8 @@ def item_change_ix(
     --------
     :func:`mdtools.numpy_helper_functions.locate_item_change` :
         Locate the positions of item changes in an array
+    :func:`mdtools.dtrj.trans_ix` :
+        Same function but specifically for discrete trajectories
 
     Notes
     -----

--- a/mdtools/numpy_helper_functions.py
+++ b/mdtools/numpy_helper_functions.py
@@ -785,6 +785,20 @@ def ix_of_item_change(a, axis=-1, wrap=False, prepend_zero=False):
     Get the indices of an array where its elements change along a given
     axis.
 
+    .. deprecated:: 0.0.0.dev1
+        :func:`mdtools.numpy_helper_functions.ix_of_item_change` might
+        be removed in a future release.  It is replaced by
+        :func:`mdtools.numpy_helper_functions.item_change_ix`, because
+        this function provides additional functionality.
+        :func:`mdtools.numpy_helper_functions.item_change_ix` with
+        `pin` set to ``"after"`` is equivalent to
+        :func:`mdtools.numpy_helper_functions.ix_of_item_change`.  The
+        option `tfic` is equivalent to `prepend_zero`.
+
+    .. todo::
+        Check for modules and scripts using this function before
+        removing it.
+
     Parameters
     ----------
     a : array_like
@@ -810,6 +824,11 @@ def ix_of_item_change(a, axis=-1, wrap=False, prepend_zero=False):
         Tuple of arrays, one for each dimension of `a`, containing the
         indices where the elements of `a` change.  `ix` can be used to
         index `a` and get the values of the changed elements.
+
+    See Also
+    --------
+    :func:`mdtools.numpy_helper_functions.item_change_ix` :
+        Equivalent function with additional features.
 
     Examples
     --------


### PR DESCRIPTION
This commit is just some kind of stash commit for work in progress on
discretized trajectories.

Planned work:

    - Create a consistent framework for handling discretized
      trajectories within MDTools.
    - Create a function for calculating the total numbers of transitions
      into or out of a given state.
    - Create a function for calculating a transition matrix for a given
      lag time (-> Markov Modeling).

When continuing work, please revert this commit, because this commit
just squashes all the changes done so far.