### PR TITLE
Fix Typo in Developer's Guide

### DIFF
--- a/docs/source/doc_pages/developers_guide/tutorials_guides_and_good_practices.rst
+++ b/docs/source/doc_pages/developers_guide/tutorials_guides_and_good_practices.rst
@@ -75,7 +75,7 @@ already established for research data to research software:
       Stephanie van de Sandt, Jon Ison, Paula Andrea Martinez, Peter
       McQuilton, Alfonso Valencia, Jennifer Harrow, Fotis Psomopoulos,
       Josep Ll. Gelpi, Neil Chue Hong, Carole Goble, Salvador
-      Capella-Gutierrez, `"Towards {FAIR} Principles For Research
+      Capella-Gutierrez, `"Towards FAIR Principles For Research
       Software" <https://doi.org/10.3233/DS-190026>`_, Data Science,
       2020, 3, 37-59.
 


### PR DESCRIPTION
Fix typo introduced in commit f608fa5c42970663087b19765c74c54ba922f0f0.