### PR TITLE
Feat/dtrj/state-transitions-vs-time

### DIFF
--- a/docs/source/doc_pages/scripts/discretization.rst
+++ b/docs/source/doc_pages/scripts/discretization.rst
@@ -52,3 +52,4 @@ Plot scripts
     plot_discrete_pos_trj
     plot_state_lifetime
     plot_state_lifetime_discrete
+    plot_trans_per_state_vs_time

--- a/mdtools/box.py
+++ b/mdtools/box.py
@@ -643,6 +643,9 @@ def vdist(pos1, pos2, box=None, out=None):
     :func:`MDAnalysis.analysis.distances.dist` :
         Calculate the distance between atoms in two MDAnalysis
         :class:`AtomGroups <MDAnalysis.core.groups.AtomGroup>`
+    :func:`mdtools.numpy_helper_functions.subtract_mic` :
+        Subtract two arrays element-wise respecting the minium image
+        convention
 
     Notes
     -----

--- a/mdtools/box.py
+++ b/mdtools/box.py
@@ -646,6 +646,9 @@ def vdist(pos1, pos2, box=None, out=None):
     :func:`mdtools.numpy_helper_functions.subtract_mic` :
         Subtract two arrays element-wise respecting the minium image
         convention
+    :func:`mdtools.numpy_helper_functions.diff_mic` :
+        Calculate the difference between array elements respecting the
+        minimum image convention.
 
     Notes
     -----

--- a/mdtools/dtrj.py
+++ b/mdtools/dtrj.py
@@ -1,6 +1,6 @@
 # This file is part of MDTools.
-# Copyright (C) 2021, The MDTools Development Team and all contributors
-# listed in the file AUTHORS.rst
+# Copyright (C) 2021, 2022  The MDTools Development Team and all
+# contributors listed in the file AUTHORS.rst
 #
 # MDTools is free software: you can redistribute it and/or modify it
 # under the terms of the GNU General Public License as published by the

--- a/mdtools/dtrj.py
+++ b/mdtools/dtrj.py
@@ -356,6 +356,12 @@ def trans_per_state(
         will be a 1-dimensional array that is formally the sum of the
         two above histograms: ``hist_end = np.sum(hist_end, axis=0)``.
 
+    See Also
+    --------
+    :func:`mdtools.dtrj.trans_per_state_vs_time` :
+        Count the number of transitions leading into or out of a state
+        for each frame in a discrete trajectory
+
     Notes
     -----
     The histograms contain the counts for all states ranging from the

--- a/mdtools/dtrj.py
+++ b/mdtools/dtrj.py
@@ -184,7 +184,18 @@ def locate_trans(
     )
 
 
-def trans_ix(dtrj, axis=-1, pin="end", wrap=False, tfft=False, tlft=False):
+def trans_ix(
+    dtrj,
+    axis=-1,
+    pin="end",
+    trans_type=None,
+    wrap=False,
+    tfft=False,
+    tlft=False,
+    mic=False,
+    min_state=None,
+    max_state=None,
+):
     """
     Get the frames indices of state transitions in a discrete
     trajectory.
@@ -198,11 +209,17 @@ def trans_ix(dtrj, axis=-1, pin="end", wrap=False, tfft=False, tlft=False):
         See :func:`mdtools.dtrj.locate_trans`.
     pin : {"end", "start", "both"}
         See :func:`mdtools.dtrj.locate_trans`.
+    trans_type : {None, "higher", "lower", "both"}, optional
+        See :func:`mdtools.dtrj.locate_trans`.
     wrap : bool, optional
         See :func:`mdtools.dtrj.locate_trans`.
     tfft : bool, optional
         See :func:`mdtools.dtrj.locate_trans`.
     tlft : bool, optional
+        See :func:`mdtools.dtrj.locate_trans`.
+    mic : bool, optional
+        See :func:`mdtools.dtrj.locate_trans`.
+    min_state, max_state : scalar or array_like, optional
         See :func:`mdtools.dtrj.locate_trans`.
 
     Returns
@@ -244,11 +261,22 @@ def trans_ix(dtrj, axis=-1, pin="end", wrap=False, tfft=False, tlft=False):
     (array([0, 0, 1, 1, 2, 2, 3, 3]), array([1, 3, 2, 5, 3, 4, 1, 4]))
     """
     trans = mdt.dtrj.locate_trans(
-        dtrj=dtrj, axis=axis, pin=pin, wrap=wrap, tfft=tfft, tlft=tlft
+        dtrj=dtrj,
+        axis=axis,
+        pin=pin,
+        trans_type=trans_type,
+        wrap=wrap,
+        tfft=tfft,
+        tlft=tlft,
+        mic=mic,
+        min_state=min_state,
+        max_state=max_state,
     )
-    if pin == "both":
+    if pin == "both" and trans_type == "both":
+        return tuple(tuple(np.nonzero(tr) for tr in trns) for trns in trans)
+    elif pin == "both" or trans_type == "both":
         return tuple(np.nonzero(tr) for tr in trans)
-    else:
+    else:  # pin != "both" and trans_type != "both"
         return np.nonzero(trans)
 
 

--- a/mdtools/file_handler.py
+++ b/mdtools/file_handler.py
@@ -847,5 +847,4 @@ def load_dtrj(fname, **kwargs):
     the loaded :class:`numpy.ndarray` is a suitable discrete trajectory.
     """
     dtrj = np.load(fname, **kwargs)
-    mdt.check.dtrj(dtrj)
-    return dtrj
+    return mdt.check.dtrj(dtrj)

--- a/mdtools/numpy_helper_functions.py
+++ b/mdtools/numpy_helper_functions.py
@@ -1,6 +1,6 @@
 # This file is part of MDTools.
-# Copyright (C) 2021, The MDTools Development Team and all contributors
-# listed in the file AUTHORS.rst
+# Copyright (C) 2021, 2022  The MDTools Development Team and all
+# contributors listed in the file AUTHORS.rst
 #
 # MDTools is free software: you can redistribute it and/or modify it
 # under the terms of the GNU General Public License as published by the

--- a/mdtools/numpy_helper_functions.py
+++ b/mdtools/numpy_helper_functions.py
@@ -2409,7 +2409,16 @@ array([], shape=(2, 0), dtype=bool))
 
 
 def item_change_ix(
-    a, axis=-1, pin="after", wrap=False, tfic=False, tlic=False
+    a,
+    axis=-1,
+    pin="after",
+    change_type=None,
+    wrap=False,
+    tfic=False,
+    tlic=False,
+    mic=False,
+    amin=None,
+    amax=None,
 ):
     """
     Get the indices of item changes in an array.
@@ -2422,11 +2431,17 @@ def item_change_ix(
         See :func:`mdtools.numpy_helper_functions.locate_item_change`.
     pin : {"after", "before", "both"}
         See :func:`mdtools.numpy_helper_functions.locate_item_change`.
+    change_type : {None, "higher", "lower", "both"}, optional
+        See :func:`mdtools.numpy_helper_functions.locate_item_change`.
     wrap : bool, optional
         See :func:`mdtools.numpy_helper_functions.locate_item_change`.
     tfic : bool, optional
         See :func:`mdtools.numpy_helper_functions.locate_item_change`.
     tlic : bool, optional
+        See :func:`mdtools.numpy_helper_functions.locate_item_change`.
+    mic : bool, optional
+        See :func:`mdtools.numpy_helper_functions.locate_item_change`.
+    amin, amax : scalar or array_like, optional
         See :func:`mdtools.numpy_helper_functions.locate_item_change`.
 
     Returns
@@ -2462,6 +2477,27 @@ def item_change_ix(
     (array([0, 2]),)
     >>> after
     (array([1, 3]),)
+    >>> before_type, after_type = mdt.nph.item_change_ix(
+    ...     a, pin="both", change_type="both"
+    ... )
+    >>> before_type[0]  # Changes to higher values
+    (array([0, 2]),)
+    >>> before_type[1]  # Changes to lower values
+    (array([], dtype=int64),)
+    >>> for i, bt in enumerate(zip(*before_type)):
+    ...     np.array_equal(
+    ...         np.sort(np.concatenate(bt)), np.sort(before[i])
+    ...     )
+    True
+    >>> after_type[0]  # Changes to higher values
+    (array([1, 3]),)
+    >>> after_type[1]  # Changes to lower values
+    (array([], dtype=int64),)
+    >>> for i, at in enumerate(zip(*after_type)):
+    ...     np.array_equal(
+    ...         np.sort(np.concatenate(at)), np.sort(after[i])
+    ...     )
+    True
     >>> before_wrap, after_wrap = mdt.nph.item_change_ix(
     ...     a, pin="both", wrap=True
     ... )
@@ -2469,6 +2505,27 @@ def item_change_ix(
     (array([0, 2, 5]),)
     >>> after_wrap
     (array([0, 1, 3]),)
+    >>> before_type_wrap, after_type_wrap = mdt.nph.item_change_ix(
+    ...     a, pin="both", change_type="both", wrap=True
+    ... )
+    >>> before_type_wrap[0]
+    (array([0, 2]),)
+    >>> before_type_wrap[1]
+    (array([5]),)
+    >>> for i, btw in enumerate(zip(*before_type_wrap)):
+    ...     np.array_equal(
+    ...         np.sort(np.concatenate(btw)), np.sort(before_wrap[i])
+    ...     )
+    True
+    >>> after_type_wrap[0]
+    (array([1, 3]),)
+    >>> after_type_wrap[1]
+    (array([0]),)
+    >>> for i, atw in enumerate(zip(*after_type_wrap)):
+    ...     np.array_equal(
+    ...         np.sort(np.concatenate(atw)), np.sort(after_wrap[i])
+    ...     )
+    True
     >>> before_tfic, after_tfic = mdt.nph.item_change_ix(
     ...     a, pin="both", tfic=True
     ... )
@@ -2497,6 +2554,27 @@ def item_change_ix(
     (array([0, 2, 5]),)
     >>> after
     (array([1, 3, 6]),)
+    >>> before_type, after_type = mdt.nph.item_change_ix(
+    ...     a, pin="both", change_type="both"
+    ... )
+    >>> before_type[0]
+    (array([0, 2]),)
+    >>> before_type[1]
+    (array([5]),)
+    >>> for i, bt in enumerate(zip(*before_type)):
+    ...     np.array_equal(
+    ...         np.sort(np.concatenate(bt)), np.sort(before[i])
+    ...     )
+    True
+    >>> after_type[0]
+    (array([1, 3]),)
+    >>> after_type[1]
+    (array([6]),)
+    >>> for i, at in enumerate(zip(*after_type)):
+    ...     np.array_equal(
+    ...         np.sort(np.concatenate(at)), np.sort(after[i])
+    ...     )
+    True
     >>> before_wrap, after_wrap = mdt.nph.item_change_ix(
     ...     a, pin="both", wrap=True
     ... )
@@ -2504,6 +2582,27 @@ def item_change_ix(
     (array([0, 2, 5]),)
     >>> after_wrap
     (array([1, 3, 6]),)
+    >>> before_type_wrap, after_type_wrap = mdt.nph.item_change_ix(
+    ...     a, pin="both", change_type="both"
+    ... )
+    >>> before_type_wrap[0]
+    (array([0, 2]),)
+    >>> before_type_wrap[1]
+    (array([5]),)
+    >>> for i, btw in enumerate(zip(*before_type_wrap)):
+    ...     np.array_equal(
+    ...         np.sort(np.concatenate(btw)), np.sort(before_wrap[i])
+    ...     )
+    True
+    >>> after_type_wrap[0]
+    (array([1, 3]),)
+    >>> after_type_wrap[1]
+    (array([6]),)
+    >>> for i, atw in enumerate(zip(*after_type_wrap)):
+    ...     np.array_equal(
+    ...         np.sort(np.concatenate(atw)), np.sort(after_wrap[i])
+    ...     )
+    True
     >>> before_tfic_tlic, after_tfic_tlic = mdt.nph.item_change_ix(
     ...     a, pin="both", tfic=True, tlic=True
     ... )
@@ -2523,6 +2622,29 @@ def item_change_ix(
     (array([0, 0, 1, 1]), array([0, 1, 1, 2]))
     >>> after
     (array([1, 1, 2, 2]), array([0, 1, 1, 2]))
+    >>> before_type, after_type = mdt.nph.item_change_ix(
+    ...     a, axis=ax, pin="both", change_type="both"
+    ... )
+    >>> before_type[0]
+    (array([0, 1]), array([0, 1]))
+    >>> before_type[1]
+    (array([0, 1]), array([1, 2]))
+    >>> for i, bt in enumerate(zip(*before_type)):
+    ...     np.array_equal(
+    ...         np.sort(np.concatenate(bt)), np.sort(before[i])
+    ...     )
+    True
+    True
+    >>> after_type[0]
+    (array([1, 2]), array([0, 1]))
+    >>> after_type[1]
+    (array([1, 2]), array([1, 2]))
+    >>> for i, at in enumerate(zip(*after_type)):
+    ...     np.array_equal(
+    ...         np.sort(np.concatenate(at)), np.sort(after[i])
+    ...     )
+    True
+    True
     >>> before_wrap, after_wrap = mdt.nph.item_change_ix(
     ...     a, axis=ax, pin="both", wrap=True
     ... )
@@ -2533,6 +2655,29 @@ def item_change_ix(
     >>> before_tfic_tlic, after_tfic_tlic = mdt.nph.item_change_ix(
     ...     a, axis=ax, pin="both", tfic=True, tlic=True
     ... )
+    >>> before_type_wrap, after_type_wrap = mdt.nph.item_change_ix(
+    ...     a, axis=ax, pin="both", change_type="both", wrap=True
+    ... )
+    >>> before_type_wrap[0]
+    (array([0, 1, 2]), array([0, 1, 2]))
+    >>> before_type_wrap[1]
+    (array([0, 1, 2]), array([1, 2, 0]))
+    >>> for i, btw in enumerate(zip(*before_type_wrap)):
+    ...     np.array_equal(
+    ...         np.sort(np.concatenate(btw)), np.sort(before_wrap[i])
+    ...     )
+    True
+    True
+    >>> after_type_wrap[0]
+    (array([0, 1, 2]), array([2, 0, 1]))
+    >>> after_type_wrap[1]
+    (array([0, 1, 2]), array([0, 1, 2]))
+    >>> for i, atw in enumerate(zip(*after_type_wrap)):
+    ...     np.array_equal(
+    ...         np.sort(np.concatenate(atw)), np.sort(after_wrap[i])
+    ...     )
+    True
+    True
     >>> before_tfic_tlic
     (array([0, 0, 1, 1, 2, 2, 2, 2]), array([0, 1, 1, 2, 0, 1, 2, 3]))
     >>> after_tfic_tlic
@@ -2544,6 +2689,29 @@ def item_change_ix(
     (array([0, 1, 1, 2, 2]), array([0, 0, 1, 1, 2]))
     >>> after
     (array([0, 1, 1, 2, 2]), array([1, 1, 2, 2, 3]))
+    >>> before_type, after_type = mdt.nph.item_change_ix(
+    ...     a, axis=ax, pin="both", change_type="both"
+    ... )
+    >>> before_type[0]
+    (array([0, 1, 2]), array([0, 1, 2]))
+    >>> before_type[1]
+    (array([1, 2]), array([0, 1]))
+    >>> for i, bt in enumerate(zip(*before_type)):
+    ...     np.array_equal(
+    ...         np.sort(np.concatenate(bt)), np.sort(before[i])
+    ...     )
+    True
+    True
+    >>> after_type[0]
+    (array([0, 1, 2]), array([1, 2, 3]))
+    >>> after_type[1]
+    (array([1, 2]), array([1, 2]))
+    >>> for i, at in enumerate(zip(*after_type)):
+    ...     np.array_equal(
+    ...         np.sort(np.concatenate(at)), np.sort(after[i])
+    ...     )
+    True
+    True
     >>> before_wrap, after_wrap = mdt.nph.item_change_ix(
     ...     a, axis=ax, pin="both", wrap=True
     ... )
@@ -2551,6 +2719,29 @@ def item_change_ix(
     (array([0, 0, 1, 1, 2, 2]), array([0, 3, 0, 1, 1, 2]))
     >>> after_wrap
     (array([0, 0, 1, 1, 2, 2]), array([0, 1, 1, 2, 2, 3]))
+    >>> before_type_wrap, after_type_wrap = mdt.nph.item_change_ix(
+    ...     a, axis=ax, pin="both", change_type="both", wrap=True
+    ... )
+    >>> before_type_wrap[0]
+    (array([0, 1, 2]), array([0, 1, 2]))
+    >>> before_type_wrap[1]
+    (array([0, 1, 2]), array([3, 0, 1]))
+    >>> for i, btw in enumerate(zip(*before_type_wrap)):
+    ...     np.array_equal(
+    ...         np.sort(np.concatenate(btw)), np.sort(before_wrap[i])
+    ...     )
+    True
+    True
+    >>> after_type_wrap[0]
+    (array([0, 1, 2]), array([1, 2, 3]))
+    >>> after_type_wrap[1]
+    (array([0, 1, 2]), array([0, 1, 2]))
+    >>> for i, atw in enumerate(zip(*after_type_wrap)):
+    ...     np.array_equal(
+    ...         np.sort(np.concatenate(atw)), np.sort(after_wrap[i])
+    ...     )
+    True
+    True
     >>> before_tfic_tlic, after_tfic_tlic = mdt.nph.item_change_ix(
     ...     a, axis=ax, pin="both", tfic=True, tlic=True
     ... )
@@ -2572,6 +2763,31 @@ def item_change_ix(
     (array([0, 0, 0, 0]), array([0, 0, 1, 1]), array([0, 2, 0, 2]))
     >>> after
     (array([1, 1, 1, 1]), array([0, 0, 1, 1]), array([0, 2, 0, 2]))
+    >>> before_type, after_type = mdt.nph.item_change_ix(
+    ...     a, axis=ax, pin="both", change_type="both"
+    ... )
+    >>> before_type[0]
+    (array([0, 0]), array([0, 1]), array([0, 2]))
+    >>> before_type[1]
+    (array([0, 0]), array([0, 1]), array([2, 0]))
+    >>> for i, bt in enumerate(zip(*before_type)):
+    ...     np.array_equal(
+    ...         np.sort(np.concatenate(bt)), np.sort(before[i])
+    ...     )
+    True
+    True
+    True
+    >>> after_type[0]
+    (array([1, 1]), array([0, 1]), array([0, 2]))
+    >>> after_type[1]
+    (array([1, 1]), array([0, 1]), array([2, 0]))
+    >>> for i, at in enumerate(zip(*after_type)):
+    ...     np.array_equal(
+    ...         np.sort(np.concatenate(at)), np.sort(after[i])
+    ...     )
+    True
+    True
+    True
     >>> before_wrap, after_wrap = mdt.nph.item_change_ix(
     ...     a, axis=ax, pin="both", wrap=True
     ... )
@@ -2583,6 +2799,31 @@ array([0, 2, 0, 2, 0, 2, 0, 2]))
     (array([0, 0, 0, 0, 1, 1, 1, 1]), \
 array([0, 0, 1, 1, 0, 0, 1, 1]), \
 array([0, 2, 0, 2, 0, 2, 0, 2]))
+    >>> before_type_wrap, after_type_wrap = mdt.nph.item_change_ix(
+    ...     a, axis=ax, pin="both", change_type="both", wrap=True
+    ... )
+    >>> before_type_wrap[0]
+    (array([0, 0, 1, 1]), array([0, 1, 0, 1]), array([0, 2, 2, 0]))
+    >>> before_type_wrap[1]
+    (array([0, 0, 1, 1]), array([0, 1, 0, 1]), array([2, 0, 0, 2]))
+    >>> for i, btw in enumerate(zip(*before_type_wrap)):
+    ...     np.array_equal(
+    ...         np.sort(np.concatenate(btw)), np.sort(before_wrap[i])
+    ...     )
+    True
+    True
+    True
+    >>> after_type_wrap[0]
+    (array([0, 0, 1, 1]), array([0, 1, 0, 1]), array([2, 0, 0, 2]))
+    >>> after_type_wrap[1]
+    (array([0, 0, 1, 1]), array([0, 1, 0, 1]), array([0, 2, 2, 0]))
+    >>> for i, atw in enumerate(zip(*after_type_wrap)):
+    ...     np.array_equal(
+    ...         np.sort(np.concatenate(atw)), np.sort(after_wrap[i])
+    ...     )
+    True
+    True
+    True
     >>> before_tfic_tlic, after_tfic_tlic = mdt.nph.item_change_ix(
     ...     a, axis=ax, pin="both", tfic=True, tlic=True
     ... )
@@ -2594,13 +2835,38 @@ array([0, 2, 0, 2, 0, 1, 2, 0, 1, 2]))
     (array([0, 0, 0, 0, 0, 0, 1, 1, 1, 1]), \
 array([0, 0, 0, 1, 1, 1, 0, 0, 1, 1]), \
 array([0, 1, 2, 0, 1, 2, 0, 2, 0, 2]))
-
     >>> ax = 1
     >>> before, after = mdt.nph.item_change_ix(a, axis=ax, pin="both")
     >>> before
     (array([0, 0, 1, 1]), array([0, 0, 0, 0]), array([0, 2, 0, 2]))
     >>> after
     (array([0, 0, 1, 1]), array([1, 1, 1, 1]), array([0, 2, 0, 2]))
+
+    >>> before_type, after_type = mdt.nph.item_change_ix(
+    ...     a, axis=ax, pin="both", change_type="both"
+    ... )
+    >>> before_type[0]
+    (array([0, 1]), array([0, 0]), array([0, 2]))
+    >>> before_type[1]
+    (array([0, 1]), array([0, 0]), array([2, 0]))
+    >>> for i, bt in enumerate(zip(*before_type)):
+    ...     np.array_equal(
+    ...         np.sort(np.concatenate(bt)), np.sort(before[i])
+    ...     )
+    True
+    True
+    True
+    >>> after_type[0]
+    (array([0, 1]), array([1, 1]), array([0, 2]))
+    >>> after_type[1]
+    (array([0, 1]), array([1, 1]), array([2, 0]))
+    >>> for i, at in enumerate(zip(*after_type)):
+    ...     np.array_equal(
+    ...         np.sort(np.concatenate(at)), np.sort(after[i])
+    ...     )
+    True
+    True
+    True
     >>> before_wrap, after_wrap = mdt.nph.item_change_ix(
     ...     a, axis=ax, pin="both", wrap=True
     ... )
@@ -2612,6 +2878,31 @@ array([0, 2, 0, 2, 0, 2, 0, 2]))
     (array([0, 0, 0, 0, 1, 1, 1, 1]), \
 array([0, 0, 1, 1, 0, 0, 1, 1]), \
 array([0, 2, 0, 2, 0, 2, 0, 2]))
+    >>> before_type_wrap, after_type_wrap = mdt.nph.item_change_ix(
+    ...     a, axis=ax, pin="both", change_type="both", wrap=True
+    ... )
+    >>> before_type_wrap[0]
+    (array([0, 0, 1, 1]), array([0, 1, 0, 1]), array([0, 2, 2, 0]))
+    >>> before_type_wrap[1]
+    (array([0, 0, 1, 1]), array([0, 1, 0, 1]), array([2, 0, 0, 2]))
+    >>> for i, btw in enumerate(zip(*before_type_wrap)):
+    ...     np.array_equal(
+    ...         np.sort(np.concatenate(btw)), np.sort(before_wrap[i])
+    ...     )
+    True
+    True
+    True
+    >>> after_type_wrap[0]
+    (array([0, 0, 1, 1]), array([0, 1, 0, 1]), array([2, 0, 0, 2]))
+    >>> after_type_wrap[1]
+    (array([0, 0, 1, 1]), array([0, 1, 0, 1]), array([0, 2, 2, 0]))
+    >>> for i, atw in enumerate(zip(*after_type_wrap)):
+    ...     np.array_equal(
+    ...         np.sort(np.concatenate(atw)), np.sort(after_wrap[i])
+    ...     )
+    True
+    True
+    True
     >>> before_tfic_tlic, after_tfic_tlic = mdt.nph.item_change_ix(
     ...     a, axis=ax, pin="both", tfic=True, tlic=True
     ... )
@@ -2630,6 +2921,31 @@ array([0, 1, 2, 0, 2, 0, 1, 2, 0, 2]))
     (array([0, 0, 1, 1]), array([0, 1, 0, 1]), array([0, 1, 1, 0]))
     >>> after
     (array([0, 0, 1, 1]), array([0, 1, 0, 1]), array([1, 2, 2, 1]))
+    >>> before_type, after_type = mdt.nph.item_change_ix(
+    ...     a, axis=ax, pin="both", change_type="both"
+    ... )
+    >>> before_type[0]
+    (array([0, 1]), array([0, 1]), array([0, 0]))
+    >>> before_type[1]
+    (array([0, 1]), array([1, 0]), array([1, 1]))
+    >>> for i, bt in enumerate(zip(*before_type)):
+    ...     np.array_equal(
+    ...         np.sort(np.concatenate(bt)), np.sort(before[i])
+    ...     )
+    True
+    True
+    True
+    >>> after_type[0]
+    (array([0, 1]), array([0, 1]), array([1, 1]))
+    >>> after_type[1]
+    (array([0, 1]), array([1, 0]), array([2, 2]))
+    >>> for i, at in enumerate(zip(*after_type)):
+    ...     np.array_equal(
+    ...         np.sort(np.concatenate(at)), np.sort(after[i])
+    ...     )
+    True
+    True
+    True
     >>> before_wrap, after_wrap = mdt.nph.item_change_ix(
     ...     a, axis=ax, pin="both", wrap=True
     ... )
@@ -2641,6 +2957,31 @@ array([0, 2, 1, 2, 1, 2, 0, 2]))
     (array([0, 0, 0, 0, 1, 1, 1, 1]), \
 array([0, 0, 1, 1, 0, 0, 1, 1]), \
 array([0, 1, 0, 2, 0, 2, 0, 1]))
+    >>> before_type_wrap, after_type_wrap = mdt.nph.item_change_ix(
+    ...     a, axis=ax, pin="both", change_type="both", wrap=True
+    ... )
+    >>> before_type_wrap[0]
+    (array([0, 0, 1, 1]), array([0, 1, 0, 1]), array([0, 2, 2, 0]))
+    >>> before_type_wrap[1]
+    (array([0, 0, 1, 1]), array([0, 1, 0, 1]), array([2, 1, 1, 2]))
+    >>> for i, btw in enumerate(zip(*before_type_wrap)):
+    ...     np.array_equal(
+    ...         np.sort(np.concatenate(btw)), np.sort(before_wrap[i])
+    ...     )
+    True
+    True
+    True
+    >>> after_type_wrap[0]
+    (array([0, 0, 1, 1]), array([0, 1, 0, 1]), array([1, 0, 0, 1]))
+    >>> after_type_wrap[1]
+    (array([0, 0, 1, 1]), array([0, 1, 0, 1]), array([0, 2, 2, 0]))
+    >>> for i, atw in enumerate(zip(*after_type_wrap)):
+    ...     np.array_equal(
+    ...         np.sort(np.concatenate(atw)), np.sort(after_wrap[i])
+    ...     )
+    True
+    True
+    True
     >>> before_tfic_tlic, after_tfic_tlic = mdt.nph.item_change_ix(
     ...     a, axis=ax, pin="both", tfic=True, tlic=True
     ... )
@@ -2657,18 +2998,24 @@ array([0, 1, 0, 2, 0, 2, 0, 1]))
 
     >>> a = np.array([[1, 2, 2]])
     >>> ax = 0
-    >>> before, after = mdt.nph.item_change_ix(a, axis=ax, pin="both")
-    >>> before
-    (array([], dtype=int64), array([], dtype=int64))
-    >>> after
-    (array([], dtype=int64), array([], dtype=int64))
-    >>> before_wrap, after_wrap = mdt.nph.item_change_ix(
-    ...     a, axis=ax, pin="both", wrap=True
+    >>> before_type, after_type = mdt.nph.item_change_ix(
+    ...     a, axis=ax, pin="both", change_type="both"
     ... )
-    >>> before_wrap
-    (array([], dtype=int64), array([], dtype=int64))
-    >>> after_wrap
-    (array([], dtype=int64), array([], dtype=int64))
+    >>> before_type
+    ((array([], dtype=int64), array([], dtype=int64)), \
+(array([], dtype=int64), array([], dtype=int64)))
+    >>> after_type
+    ((array([], dtype=int64), array([], dtype=int64)), \
+(array([], dtype=int64), array([], dtype=int64)))
+    >>> before_type_wrap, after_type_wrap = mdt.nph.item_change_ix(
+    ...     a, axis=ax, pin="both", change_type="both", wrap=True
+    ... )
+    >>> before_type_wrap
+    ((array([], dtype=int64), array([], dtype=int64)), \
+(array([], dtype=int64), array([], dtype=int64)))
+    >>> after_type_wrap
+    ((array([], dtype=int64), array([], dtype=int64)), \
+(array([], dtype=int64), array([], dtype=int64)))
     >>> before_tfic_tlic, after_tfic_tlic = mdt.nph.item_change_ix(
     ...     a, axis=ax, pin="both", tfic=True, tlic=True
     ... )
@@ -2677,18 +3024,22 @@ array([0, 1, 0, 2, 0, 2, 0, 1]))
     >>> after_tfic_tlic
     (array([0, 0, 0]), array([0, 1, 2]))
     >>> ax = 1
-    >>> before, after = mdt.nph.item_change_ix(a, axis=ax, pin="both")
-    >>> before
-    (array([0]), array([0]))
-    >>> after
-    (array([0]), array([1]))
-    >>> before_wrap, after_wrap = mdt.nph.item_change_ix(
-    ...     a, axis=ax, pin="both", wrap=True
+    >>> before_type, after_type = mdt.nph.item_change_ix(
+    ...     a, axis=ax, pin="both", change_type="both"
     ... )
-    >>> before_wrap
-    (array([0, 0]), array([0, 2]))
-    >>> after_wrap
-    (array([0, 0]), array([0, 1]))
+    >>> before_type
+    ((array([0]), array([0])), \
+(array([], dtype=int64), array([], dtype=int64)))
+    >>> after_type
+    ((array([0]), array([1])), \
+(array([], dtype=int64), array([], dtype=int64)))
+    >>> before_type_wrap, after_type_wrap = mdt.nph.item_change_ix(
+    ...     a, axis=ax, pin="both", change_type="both", wrap=True
+    ... )
+    >>> before_type_wrap
+    ((array([0]), array([0])), (array([0]), array([2])))
+    >>> after_type_wrap
+    ((array([0]), array([1])), (array([0]), array([0])))
     >>> before_tfic_tlic, after_tfic_tlic = mdt.nph.item_change_ix(
     ...     a, axis=ax, pin="both", tfic=True, tlic=True
     ... )
@@ -2704,6 +3055,15 @@ array([0, 1, 0, 2, 0, 2, 0, 1]))
     (array([], dtype=int64), array([], dtype=int64))
     >>> after
     (array([], dtype=int64), array([], dtype=int64))
+    >>> before_type, after_type = mdt.nph.item_change_ix(
+    ...     a, axis=ax, pin="both", change_type="both"
+    ... )
+    >>> before_type
+    ((array([], dtype=int64), array([], dtype=int64)), \
+(array([], dtype=int64), array([], dtype=int64)))
+    >>> after_type
+    ((array([], dtype=int64), array([], dtype=int64)), \
+(array([], dtype=int64), array([], dtype=int64)))
     >>> before_wrap, after_wrap = mdt.nph.item_change_ix(
     ...     a, axis=ax, pin="both", wrap=True
     ... )
@@ -2711,6 +3071,15 @@ array([0, 1, 0, 2, 0, 2, 0, 1]))
     (array([], dtype=int64), array([], dtype=int64))
     >>> after_wrap
     (array([], dtype=int64), array([], dtype=int64))
+    >>> before_type_wrap, after_type = mdt.nph.item_change_ix(
+    ...     a, axis=ax, pin="both", change_type="both", wrap=True
+    ... )
+    >>> before_type_wrap
+    ((array([], dtype=int64), array([], dtype=int64)), \
+(array([], dtype=int64), array([], dtype=int64)))
+    >>> after_type
+    ((array([], dtype=int64), array([], dtype=int64)), \
+(array([], dtype=int64), array([], dtype=int64)))
     >>> before_tfic_tlic, after_tfic_tlic = mdt.nph.item_change_ix(
     ...     a, axis=ax, pin="both", tfic=True, tlic=True
     ... )
@@ -2724,6 +3093,15 @@ array([0, 1, 0, 2, 0, 2, 0, 1]))
     (array([], dtype=int64), array([], dtype=int64))
     >>> after
     (array([], dtype=int64), array([], dtype=int64))
+    >>> before_type, after_type = mdt.nph.item_change_ix(
+    ...     a, axis=ax, pin="both", change_type="both"
+    ... )
+    >>> before_type
+    ((array([], dtype=int64), array([], dtype=int64)), \
+(array([], dtype=int64), array([], dtype=int64)))
+    >>> after_type
+    ((array([], dtype=int64), array([], dtype=int64)), \
+(array([], dtype=int64), array([], dtype=int64)))
     >>> before_wrap, after_wrap = mdt.nph.item_change_ix(
     ...     a, axis=ax, pin="both", wrap=True
     ... )
@@ -2731,6 +3109,15 @@ array([0, 1, 0, 2, 0, 2, 0, 1]))
     (array([], dtype=int64), array([], dtype=int64))
     >>> after_wrap
     (array([], dtype=int64), array([], dtype=int64))
+    >>> before_type_wrap, after_type = mdt.nph.item_change_ix(
+    ...     a, axis=ax, pin="both", change_type="both", wrap=True
+    ... )
+    >>> before_type_wrap
+    ((array([], dtype=int64), array([], dtype=int64)), \
+(array([], dtype=int64), array([], dtype=int64)))
+    >>> after_type
+    ((array([], dtype=int64), array([], dtype=int64)), \
+(array([], dtype=int64), array([], dtype=int64)))
     >>> before_tfic_tlic, after_tfic_tlic = mdt.nph.item_change_ix(
     ...     a, axis=ax, pin="both", tfic=True, tlic=True
     ... )
@@ -2887,11 +3274,24 @@ array([0, 1, 0, 2, 0, 2, 0, 1]))
     ValueError: The dimension of a must be greater than zero
     """
     item_changes = mdt.nph.locate_item_change(
-        a=a, axis=axis, pin=pin, wrap=wrap, tfic=tfic, tlic=tlic
+        a=a,
+        axis=axis,
+        pin=pin,
+        change_type=change_type,
+        wrap=wrap,
+        tfic=tfic,
+        tlic=tlic,
+        mic=mic,
+        amin=amin,
+        amax=amax,
     )
-    if pin == "both":
+    if pin == "both" and change_type == "both":
+        return tuple(
+            tuple(np.nonzero(ic) for ic in ics) for ics in item_changes
+        )
+    elif pin == "both" or change_type == "both":
         return tuple(np.nonzero(ic) for ic in item_changes)
-    else:
+    else:  # pin != "both" and change_type != "both"
         return np.nonzero(item_changes)
 
 

--- a/mdtools/numpy_helper_functions.py
+++ b/mdtools/numpy_helper_functions.py
@@ -1020,6 +1020,9 @@ def subtract_mic(x1, x2, amin=None, amax=None, **kwargs):
     See Also
     --------
     :func:`numpy.subtract` : Subtract two arrays element-wise
+    :func:`mdtools.numpy_helper_functions.diff_mic` :
+        Calculate the difference between array elements respecting the
+        minimum image convention.
     :func:`mdtools.box.vdist` :
         Calculate the distance vectors between two position arrays
 

--- a/scripts/discretization/plot_trans_per_state_vs_time.py
+++ b/scripts/discretization/plot_trans_per_state_vs_time.py
@@ -1,0 +1,362 @@
+#!/usr/bin/env python3
+
+# This file is part of MDTools.
+# Copyright (C) 2021, 2022  The MDTools Development Team and all
+# contributors listed in the file AUTHORS.rst
+#
+# MDTools is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version.
+#
+# MDTools is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with MDTools.  If not, see <http://www.gnu.org/licenses/>.
+
+
+"""
+Plot the number of transitions leading into or out of a given state for
+each frame in a discrete trajectory as function of time.
+
+Options
+-------
+-f          Trajectory file.  File containing the discrete trajectory
+            stored as :class:`numpy.ndarray` in the binary :file:`.npy`
+            format.  The array must be of shape ``(n, f)``, where ``n``
+            is the number of compounds and ``f`` is the number of
+            frames.  The shape can also be ``(f,)``, in which case the
+            array is expanded to shape ``(1, f)``.  All elements of the
+            array must be integers or floats whose fractional part is
+            zero, because they are interpreted as the indices of the
+            states in which a given compound is at a given frame.
+-o          Output filename.
+-b          First frame to read from the trajectory.  Frame numbering
+            starts at zero.  Default: ``0``.
+-e          Last frame to read from the trajectory.  This is exclusive,
+            i.e. the last frame read is actually ``END - 1``.  A value
+            of ``-1`` means to read the very last frame.  Default:
+            ``-1``.
+--every     Read every n-th frame from the trajectory.  Default: ``1``.
+--cumsum    Calculate and plot the cumulative sum of transitions per
+            state over time.
+--fit       Fit the number of transitions leading into or out of the
+            central state by a power law.
+--labels    One label for each state in the discrete trajectory.  The
+            labels will be shown in the legend of the plot.  If
+            provided, you must give one label for each state.  By
+            default the states are numbered consecutively from
+            ``MIN_STATE`` to ``MAX_STATE``.  Default: ``None``.
+--xlim      Left and right limit of the x-axis in data coordinates.
+            Pass 'None' to adjust the limit(s) automatically.  Default:
+            ``[None, None]``.
+--ylim      Lower and upper limit of the y-axis in data coordinates.
+            Pass 'None' to adjust the limit(s) automatically.  Default:
+            ``[None, None]``.
+--log       Whether to use a logarithmic scale for the x- and/or y-axis.
+            Default:  ``[False, False]``.
+
+See Also
+--------
+:func:`mdtools.dtrj.trans_per_state_vs_time` :
+    Function that counts the number of transitions leading into or out
+    of a state for each frame in the discrete trajectory
+
+Examples
+--------
+TODO
+"""
+
+
+__author__ = "Andreas Thum"
+
+
+# Standard libraries
+import argparse
+import os
+import sys
+from datetime import datetime, timedelta
+
+# Third party libraries
+import matplotlib.pyplot as plt
+import numpy as np
+import psutil
+from matplotlib.backends.backend_pdf import PdfPages
+from scipy.optimize import curve_fit
+
+# Local application/library specific imports
+import mdtools as mdt
+import mdtools.plot as mdtplt  # noqa: F401; Import MDTools plot style
+
+
+def power_law(x, a, b):
+    """
+    Power law to use as fit function.
+
+    Parameters
+    ----------
+    x : scalar or numpy.ndarray
+        The sample point(s) for the function
+    a : scalar or numpy.ndarray
+        Prefactor.
+    b : scalar or numpy.ndarray
+        Exponent.
+
+    Returns
+    -------
+    result : scalar or numpy.ndarray
+        ``a * x**b``
+    """
+    return a * x**b
+
+
+if __name__ == "__main__":
+    timer_tot = datetime.now()
+    proc = psutil.Process()
+    proc.cpu_percent()  # Initiate monitoring of CPU usage
+    parser = argparse.ArgumentParser(
+        description=(
+            "Plot the number of transitions leading into or out of a given"
+            " state for each frame in a discrete trajectory as function of"
+            " time"
+        )
+    )
+    parser.add_argument(
+        "-f",
+        dest="TRJFILE",
+        type=str,
+        required=True,
+        help=(
+            "Trajectory file containing the discrete trajectory stored as"
+            " numpy.ndarray in the binary .npy format."
+        ),
+    )
+    parser.add_argument(
+        "-o",
+        dest="OUTFILE",
+        type=str,
+        required=True,
+        help=("Output filename."),
+    )
+    parser.add_argument(
+        "-b",
+        dest="BEGIN",
+        type=int,
+        required=False,
+        default=0,
+        help=(
+            "First frame to read from the trajectory.  Frame numbering starts"
+            " at zero.  Default: %(default)s."
+        ),
+    )
+    parser.add_argument(
+        "-e",
+        dest="END",
+        type=int,
+        required=False,
+        default=-1,
+        help=(
+            "Last frame to read from the trajectory (exclusive).  Default:"
+            " %(default)s."
+        ),
+    )
+    parser.add_argument(
+        "--every",
+        dest="EVERY",
+        type=int,
+        required=False,
+        default=1,
+        help=(
+            "Read every n-th frame from the trajectory.  Default: %(default)s."
+        ),
+    )
+    parser.add_argument(
+        "--cumsum",
+        dest="CUMSUM",
+        required=False,
+        default=False,
+        action="store_true",
+        help="Plot the cumulative sum of transitions per state over time.",
+    )
+    parser.add_argument(
+        "--fit",
+        dest="FIT",
+        required=False,
+        default=False,
+        action="store_true",
+        help=(
+            "Fit the number of transitions leading into or out of the central"
+            " state by a power law."
+        ),
+    )
+    parser.add_argument(
+        "--labels",
+        dest="LABELS",
+        type=str,
+        nargs="+",
+        required=False,
+        default=None,
+        help=(
+            "A label for each state in the discrete trajectory.  Default:"
+            " %(default)s"
+        ),
+    )
+    parser.add_argument(
+        "--xlim",
+        dest="XLIM",
+        type=lambda val: mdt.fh.str2none_or_type(val, dtype=float),
+        nargs=2,
+        required=False,
+        default=[0, None],
+        help=(
+            "Left and right limit of the x-axis in data coordinates.  Default:"
+            " %(default)s"
+        ),
+    )
+    parser.add_argument(
+        "--ylim",
+        dest="YLIM",
+        type=lambda val: mdt.fh.str2none_or_type(val, dtype=float),
+        nargs=2,
+        required=False,
+        default=[0, None],
+        help=(
+            "Lower and upper limit of the y-axis in data coordinates."
+            "  Default: %(default)s"
+        ),
+    )
+    parser.add_argument(
+        "--log",
+        dest="LOG",
+        type=mdt.fh.str2bool,
+        nargs=2,
+        required=False,
+        default=[False, False],
+        help=(
+            "Whether to use a logarithmic scale for the x- and/or y-axis."
+            "  Default: %(default)s"
+        ),
+    )
+    args = parser.parse_args()
+    print(mdt.rti.run_time_info_str())
+
+    print("\n")
+    print("Loading discrete trajectory")
+    timer = datetime.now()
+    dtrj = mdt.fh.load_dtrj(args.TRJFILE)
+    N_CMPS, N_FRAMES_TOT = dtrj.shape
+    BEGIN, END, EVERY, N_FRAMES = mdt.check.frame_slicing(
+        start=args.BEGIN,
+        stop=args.END,
+        step=args.EVERY,
+        n_frames_tot=N_FRAMES_TOT,
+    )
+    dtrj = dtrj[:, BEGIN:END:EVERY]
+    print("Elapsed time:         {}".format(datetime.now() - timer))
+    print("Current memory usage: {:.2f} MiB".format(mdt.rti.mem_usage(proc)))
+
+    print("\n")
+    print("Calculating transition histograms as function of time")
+    timer = datetime.now()
+    hist_start, hist_end = mdt.dtrj.trans_per_state_vs_time(
+        dtrj, pin="both", trans_type="both"
+    )
+    min_state = np.min(dtrj)
+    max_state = np.max(dtrj)
+    assert hist_start[0].shape[0] == max_state - min_state + 1
+    times = np.arange(0, hist_start[0].shape[1])
+    print("Elapsed time:         {}".format(datetime.now() - timer))
+    print("Current memory usage: {:.2f} MiB".format(mdt.rti.mem_usage(proc)))
+
+    print("\n")
+    print("Creating plot...")
+    timer = datetime.now()
+    if args.LABELS is None:
+        args.LABELS = np.arange(min_state, max_state + 1)
+    if len(args.LABELS) != max_state - min_state + 1:
+        raise ValueError(
+            "You must give {} labels, one for each"
+            " state".format(max_state - min_state + 1)
+        )
+    legend_titles = ("Initial States",) * 2 + ("Final States",) * 2
+    if args.CUMSUM:
+        ylabels = (
+            "Cum. Sum of pos. Trans.",
+            "Cum. Sum of neg. Trans.",
+        ) * 2
+        linestyle, marker, rasterized = "-", "", False
+    else:
+        ylabels = ("No. of pos. Trans.", "No. of neg. Trans.") * 2
+        linestyle, marker, rasterized = "", "o", True
+    cmap = plt.get_cmap()
+    mdt.fh.backup(args.OUTFILE)
+    with PdfPages(args.OUTFILE) as pdf:
+        for i, hist in enumerate(hist_start + hist_end):
+            if args.CUMSUM:
+                hist = np.cumsum(hist, axis=-1)
+            if args.FIT:
+                popt, pcov = curve_fit(
+                    power_law, xdata=times, ydata=hist[len(hist) // 2]
+                )
+                fit = power_law(times, *popt)
+            fig, ax = plt.subplots(clear=True)
+            ax.set_prop_cycle(
+                color=[
+                    cmap(i / len(args.LABELS)) for i in range(len(args.LABELS))
+                ]
+            )
+            ax.plot(
+                times,
+                hist.T,
+                linestyle=linestyle,
+                marker=marker,
+                label=args.LABELS,
+                rasterized=rasterized,
+            )
+            if args.FIT:
+                ax.plot(
+                    times,
+                    fit,
+                    color="black",
+                    linestyle="--",
+                    label=(
+                        r"$"
+                        + str("%.2f" % popt[0])
+                        + r" \cdot x^{"
+                        + str("%.2f" % popt[1])
+                        + r"}$"
+                    ),
+                )
+            if args.LOG[0]:
+                ax.set_xscale("log", base=10, subs=np.arange(2, 10))
+            if args.LOG[1]:
+                ax.set_yscale("log", base=10, subs=np.arange(2, 10))
+            ax.set(
+                xlabel="Time in Trajectory Steps",
+                ylabel=ylabels[i],
+                xlim=args.XLIM,
+                ylim=args.YLIM,
+            )
+            ax.legend(
+                title=legend_titles[i],
+                ncol=2,  # Default: 1
+                labelspacing=0.25,  # Default: 0.5
+                handlelength=1,  # Default: 2.0
+                columnspacing=1,  # Default: 2.0
+            )
+            pdf.savefig()
+        plt.close()
+    print("Created {}".format(args.OUTFILE))
+    print("Elapsed time:         {}".format(datetime.now() - timer))
+    print("Current memory usage: {:.2f} MiB".format(mdt.rti.mem_usage(proc)))
+
+    print("\n")
+    print("{} done".format(os.path.basename(sys.argv[0])))
+    print("Totally elapsed time: {}".format(datetime.now() - timer_tot))
+    _cpu_time = timedelta(seconds=sum(proc.cpu_times()[:4]))
+    print("CPU time:             {}".format(_cpu_time))
+    print("CPU usage:            {:.2f} %".format(proc.cpu_percent()))
+    print("Current memory usage: {:.2f} MiB".format(mdt.rti.mem_usage(proc)))


### PR DESCRIPTION
Add a new function (`mdtools.dtrj.trans_per_state_vs_time`) that count the number of transitions leading into or out of a state for each frame in a discrete trajectory.

Add a new script (`plot_trans_per_state_vs_time.py`) that plots the number of transitions leading into or out of a given state for each frame in a discrete trajectory as function of time.