### PR TITLE
Refactor CI Workflow

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -10,14 +10,7 @@ on:
     # The branches below must be a subset of the branches above
     branches: [main, develop]
     paths-ignore:
-      - ./.github/*template**
-      - ./.github/*TEMPLATE**
-      - ./.readthedocs.yaml
       - ./LICENSE.txt
-      - ./*.rst
-      - "**/README"
-      - "**/README.*"
-      - "**/*.md"
       - "**/*.eps"
       - "**/*.EPS"
       - "**/*.jpg"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,14 +14,7 @@ on:
     # Run this workflow on every PR, except for PRs that only changes
     # files from the following ignore list.
     paths-ignore:
-      - ./.github/*template**
-      - ./.github/*TEMPLATE**
-      - ./.readthedocs.yaml
       - ./LICENSE.txt
-      - ./*.rst
-      - "**/README"
-      - "**/README.*"
-      - "**/*.md"
       - "**/*.eps"
       - "**/*.EPS"
       - "**/*.jpg"

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,27 +1,23 @@
-# .readthedocs.yaml
-# Read the Docs configuration file
-# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+# Read the Docs configuration file.  See
+# https://docs.readthedocs.io/en/stable/config-file/v2.html
 
-# Required
+# Version of the .readthedocs.yaml config file.
 version: 2
 
-# Build documentation in the docs/ directory with Sphinx
-sphinx:
-  builder: html
-  configuration: docs/source/conf.py
-  fail_on_warning: true
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.9"
 
-# Optionally build your docs in additional formats such as PDF
-#formats:
-#  - epub
-#  - pdf
-
-# Optionally set the version of Python and requirements required to
-# build your docs
 python:
-  version: 3.8
   install:
-    - requirements: requirements.txt
-    - requirements: docs/requirements.txt
-    - method: pip
-      path: .
+    - requirements: "requirements.txt"
+    - requirements: "docs/requirements.txt"
+    # Install the project itself.
+    - method: "pip"
+      path: "."
+
+sphinx:
+  builder: "html"
+  configuration: "docs/source/conf.py"
+  fail_on_warning: true


### PR DESCRIPTION
* Remove Markdown and reStructuredText files from the list of ignored files so that the tests are also run on pull requests that only change those files.

* Update `.readthedocs.yaml` to the new configuration style.
