### PR TITLE
`attribute_hist.py`: Fix the calculation of the average mass of the selected compounds and of the compounds' center-of-mass velocities

### DIFF
--- a/scripts/other/attribute_hist.py
+++ b/scripts/other/attribute_hist.py
@@ -107,9 +107,8 @@ Options
 
 Notes
 -----
-If the selected attribute is 'velocities' or 'forces', all created
-histograms, except the last one (Euclidean norm), are fitted by Gaussian
-distribution functions:
+All created histograms, except the last one (Euclidean norm), are fitted
+by Gaussian distribution functions:
 
 .. math::
 
@@ -679,7 +678,10 @@ if __name__ == "__main__":  # noqa: C901
             aps2ms = 1e2  # Conversion factor [A/ps] -> [m/s].
             ms2aps = 1 / aps2ms  # Conversion factor [m/s] -> [A/ps].
             sigma2_ms = popt[0] * aps2ms**2  # sigma^2 in [(m/s)^2].
-            mass = np.nanmean(sel.masses)  # Mass in [u].
+            mass = mdt.strc.cmp_attr(
+                sel, cmp=args.CMP, attr="masses", weights="total"
+            )
+            mass = np.nanmean(mass)  # Mass in [u].
             mass_kg = mass * constants.atomic_mass  # Mass in [kg].
             temp = mass_kg * sigma2_ms / constants.k  # Temperature in [K].
             v_p = np.sqrt(2 * constants.k * temp / mass_kg)

--- a/scripts/other/attribute_hist.py
+++ b/scripts/other/attribute_hist.py
@@ -431,10 +431,12 @@ if __name__ == "__main__":  # noqa: C901
         napc = None
     else:
         napc = mdt.strc.natms_per_cmp(sel, cmp=args.CMP, check_contiguous=True)
-    if args.ATTR in ("velocities", "forces"):
+    if args.ATTR == "forces":
         weights = "total"
-    elif args.ATTR == "positions":
+    elif args.ATTR in ("velocities", "positions"):
         weights = "masses"
+    else:
+        raise ValueError("Unknown --attr: {}".format(args.ATTR))
 
     print("\n")
     print("Inspecting data...")

--- a/src/mdtools/structure.py
+++ b/src/mdtools/structure.py
@@ -2143,6 +2143,25 @@ def cmp_attr(ag, attr, weights=None, cmp=None, natms_per_cmp=None):
     >>> np.allclose(com1, com2, rtol=0)
     True
 
+    Center-of-mass velocity.
+
+    >>> com_vel1 = mdt.strc.cmp_attr(
+    ...     ag, cmp="residues", attr="velocities", weights="masses"
+    ... )
+    >>> com_vel2 = [
+    ...     np.sum(
+    ...         np.expand_dims(
+    ...             res.atoms.masses / np.sum(res.atoms.masses),
+    ...             axis=1
+    ...         )
+    ...         * res.atoms.velocities,
+    ...         axis=0
+    ...     )
+    ...     for res in ag.residues
+    ... ]
+    >>> np.allclose(com_vel1, com_vel2)
+    True
+
     Center of charge (the charges of each compound should not sum up to
     zero).
 
@@ -2188,14 +2207,14 @@ def cmp_attr(ag, attr, weights=None, cmp=None, natms_per_cmp=None):
     >>> res_charges2 = [sum(res.atoms.charges) for res in ag.residues]
     >>> np.allclose(res_charges1, res_charges2, rtol=0)
     True
-    >>> # Center-of-mass velocity of each residue.
-    >>> com_vel1 = mdt.strc.cmp_attr(
+    >>> # Total velocity of each residue.
+    >>> res_vel1 = mdt.strc.cmp_attr(
     ...     ag, cmp="residues", attr="velocities", weights="total"
     ... )
-    >>> com_vel2 = [
+    >>> res_vel2 = [
     ...     np.sum(res.atoms.velocities, axis=0) for res in ag.residues
     ... ]
-    >>> np.allclose(com_vel1, com_vel2)
+    >>> np.allclose(res_vel1, res_vel2)
     True
     >>> # Center-of-mass force of each residue.
     >>> com_force1 = mdt.strc.cmp_attr(


### PR DESCRIPTION
# `attribute_hist.py`: Fix the calculation of the average mass of the selected compounds and of the compounds' center-of-mass velocities

<!--
Thank you for your contribution!

Please fill out this pull request (PR) template and please take a look
at our developer's guide at
https://mdtools.readthedocs.io/en/latest/doc_pages/dev_guide/dev_guide.html
-->

<!--
Only for project maintainers, please do not remove!
Regex version for issue-labeler.
See https://github.com/github/issue-labeler

issue_labeler_regex_version=1
-->

## Type of change

* [ ] Change of core package.
* [x] Change of scripts.

<!-- Blank line -->

* [x] Bug fix.
* [ ] New feature.
* [ ] Code refactoring.
* [ ] Dependency update.
* [x] Documentation update.
* [ ] Maintenance.
* [ ] Other: *Description*.

<!-- Blank line -->

* [x] Non-breaking (backward-compatible) change.
* [ ] Breaking (non-backward-compatible) change.

## Motivation and context

<!--
If your PR resolves a distinct issue, you can remove this section or
(better) give a brief summary of that issue.
-->

What is the motivation behind your PR?  
What problem is your PR going to solve?  
Which new feature is your PR going to add and why is it required?

## Proposed changes

<!-- Give a concise summary of the most important changes. -->

* Fix the calculation of the average mass of the selected compounds (only relevant for calculating the temperature of the selected compounds from the Maxwell-Boltzmann fit of the speed distribution): Before, the mass was the average mass of all selected atoms.  Now, the mass is the average mass of all selected compounds (as stated in the documentation).

* Fix the calculation of the compounds' center-of-mass velocities. Before, the center-of-mass velocities were simply the sum of all atom velocities. Now, the atom velocities are weighted by the atoms' masses.

* Correct the example for the calculation of the center-of-mass velocity with the function `mdtools.structure.cmp_attr`.  The given example was physically wrong.

## PR checklist

<!--
Please tick the check boxes accordingly.  Mark any check boxes that do
not apply to your PR as [~].
-->

* [x] I followed the guidelines in the [Developer's guide](https://mdtools.readthedocs.io/en/latest/doc_pages/dev_guide/dev_guide.html).
* [ ] New/changed code is properly tested.
* [x] New/changed code is properly documented.
* [ ] The CI workflow is passing.
