### PR TITLE
New functions to calculate state lifetimes by counting frames

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -157,6 +157,7 @@
         "modindex",
         "molnums",
         "movav",
+        "moveaxis",
         "mplstyle",
         "nanmax",
         "nanmean",

--- a/src/mdtools/dtrj.py
+++ b/src/mdtools/dtrj.py
@@ -1320,17 +1320,46 @@ def remain_prob(  # noqa: C901
 
     .. math::
 
-        \tau = \int_0^\infty f(t) \text{ d}t =
+        \langle \tau \rangle = \int_0^\infty f(t) \text{ d}t =
         \frac{\tau_0}{\beta} \Gamma\left(\frac{1}{\beta}\right)
 
     Here, :math:`\tau_0` and :math:`\beta` are the fit parameters,
-    :math:`\tau` is the average lifetime and :math:`\Gamma(x)` is the
-    gamma function.  For physically meaningful results, :math:`\beta`
-    should be confined to :math:`0 < \beta \leq 1`.  For purely
-    exponential decay (:math:`\beta = 1`), :math:`\tau = \tau_0`
-    applies.  If the calculated probability fully decays to zero within
-    the accessible range of lag times, one can alternatively numerically
-    integrate the calculated probability directly.
+    :math:`\langle \tau \rangle` is the average lifetime and
+    :math:`\Gamma(x)` is the gamma function.  For physically meaningful
+    results, :math:`\beta` should be confined to :math:`0 < \beta \leq
+    1`.  For purely exponential decay (:math:`\beta = 1`), :math:`\tau =
+    \tau_0` applies.  If the calculated probability :math:`p(\Delta t)`
+    fully decays to zero within the accessible range of lag times, one
+    can alternatively numerically integrate the calculated probability
+    directly, instead of the fit :math:`f(t)`.
+
+    In general, the n-th moment of the underlying distribution of
+    lifetimes is given by: [3]_:sup:`,` [4]_:sup:`,` [5]_
+
+    .. math::
+
+        \langle \tau^n \rangle
+        = \frac{1}{(n-1)!} \int_0^\infty t^{n-1} f(t) \text{ d}t
+        = \frac{\tau_0^n}{\beta}
+        \frac{\Gamma\left(\frac{n}{\beta}\right)}{\Gamma(n)}
+
+    Moreover, the time-averaged lifetime is given by: [3]_
+
+    .. math::
+
+        \bar{\tau^n}
+        = \frac{
+            \int_0^\infty t^n f(t) \text{ d}t
+        }{
+            \int_0^\infty f(t) \text{ d}t
+        }
+        = \frac{\langle \tau^{n+1} \rangle}{\langle \tau \rangle} n!
+        = \tau_0^n
+        \frac{
+            \Gamma\left(\frac{n+1}{\beta}\right)
+        }{
+            \Gamma\left(\frac{1}{\beta}\right)
+        }
 
     References
     ----------
@@ -1353,6 +1382,11 @@ def remain_prob(  # noqa: C901
            Sum of Exponential Decays
            <https://doi.org/10.1103/PhysRevB.74.184430>`_,
            Physical Review B, 2006, 74, 184430.
+    .. [5] I. S. Gradshteyn, I. M. Ryzhik,
+           `Table of Integrals, Series, and Products
+           <https://archive.org/details/GradshteinI.S.RyzhikI.M.TablesOfIntegralsSeriesAndProducts>`_,
+           Academic Press, 2007, 7th edition, p. 370, Integral 3.478
+           (1.).
 
     Examples
     --------

--- a/src/mdtools/dtrj.py
+++ b/src/mdtools/dtrj.py
@@ -1703,7 +1703,7 @@ def remain_prob_discrete(  # noqa: C901
     ...                  [ 1,  3,  3,  3, -2, -2],
     ...                  [ 1,  4,  4,  4,  4, -1]])
     >>> # States of the discrete trajectory:
-    >>> # [-2         ,-1         , 1         , 2         , 3         ]
+    >>> # [-2         ,-1         , 1         , 3         , 4         ]
     >>> # Because the first and second discrete trajectories are the
     >>> # same in this example, the resulting array contains as columns
     >>> # the probability to stay in the respective state as function of


### PR DESCRIPTION
# New functions to calculate state lifetimes by counting frames

<!--
Thank you for your contribution!

Please fill out this pull request (PR) template and please take a look
at our developer's guide at
https://mdtools.readthedocs.io/en/latest/doc_pages/dev_guide/dev_guide.html
-->

<!--
Only for project maintainers, please do not remove!
Regex version for issue-labeler.
See https://github.com/github/issue-labeler

issue_labeler_regex_version=1
-->

## Type of change

* [x] Change of core package.
* [ ] Change of scripts.

<!-- Blank line -->

* [ ] Bug fix.
* [x] New feature.
* [x] Code refactoring.
* [ ] Dependency update.
* [x] Documentation update.
* [ ] Maintenance.
* [ ] Other: *Description*.

<!-- Blank line -->

* [x] Non-breaking (backward-compatible) change.
* [ ] Breaking (non-backward-compatible) change.

## Proposed changes

<!-- Give a concise summary of the most important changes. -->

New features

* Create a new function `mdtools.dtrj.lifetimes` that calculates the lifetimes for all compounds in all states of a discrete trajectory by simply counting the number of frames a given compound stays in a given state.
* Create a new function `mdtools.dtrj.lifetimes_per_state` that calculates the lifetime of each state in a discrete trajectory by simply counting the number of frames a given compound stays in a given state.

Cod refactoring

* Refactor the function `mdtools.numpy_helper_functions.group_by`:
  * Use a stable sort when sorting the keys and values with respect to the keys.  A stable sort keeps the relative order of equal elements.
  * Always check the input arguments.  The `debug` argument is now without use.
  * Add examples to the docstring.

Documentation update

* Add more information about how to calculate lifetimes from remain probabilities to the docstring of the function `mdtools.dtrj.remain_prob`.

* Correct a wrong comment in the Examples section of the docstring of the function `mdtools.dtrj.remain_prob_discrete`.

## PR checklist

<!--
Please tick the check boxes accordingly.  Mark any check boxes that do
not apply to your PR as [~].
-->

* [x] I followed the guidelines in the [Developer's guide](https://mdtools.readthedocs.io/en/latest/doc_pages/dev_guide/dev_guide.html).
* [x] New/changed code is properly tested.
* [x] New/changed code is properly documented.
* [ ] The CI workflow is passing.
