### PR TITLE
New functions to calculate transition rates from discrete trajectories

### DIFF
--- a/src/mdtools/dtrj.py
+++ b/src/mdtools/dtrj.py
@@ -37,6 +37,7 @@ def locate_trans(
     dtrj,
     axis=-1,
     pin="end",
+    discard_neg=None,
     trans_type=None,
     wrap=False,
     tfft=False,
@@ -55,7 +56,7 @@ def locate_trans(
     ----------
     dtrj : array_like
         Array containing the discrete trajectory.
-    axis : int
+    axis : int, optional
         The axis along which to search for state transitions.  For
         ordinary discrete trajectories with shape ``(n, f)`` or
         ``(f,)``, where ``n`` is the number of compounds and ``f`` is
@@ -68,6 +69,12 @@ def locate_trans(
         where a given compound is in the next state) of the state
         transitions.  If set to ``"both"``, two output arrays will be
         returned, one for ``"start"`` and one for ``"end"``.
+    discard_neg : {None, "start", "end", "both"}, optional
+        Whether to locate all state transitions (``None``) or whether to
+        discard state transitions starting from a negative state
+        (``"start"``) or ending in a negative state (``"end"``).  If set
+        to ``"both"``, all state transitions starting from or ending in
+        a negative state will be discarded.
     trans_type : {None, "higher", "lower", "both"} or int or \
 iterable of ints, optional
         Whether to locate all state transitions without discriminating
@@ -93,12 +100,12 @@ iterable of ints, optional
         Treat First Frame as Transition.  If ``True``, treat the first
         frame as the end of a state transition.  Has no effect if `pin`
         is set to ``"start"``.  Must not be used together with
-        `trans_type`, `wrap` or `mic`.
+        `discard_neg`, `trans_type`, `wrap` or `mic`.
     tlft : bool, optional
         Treat Last Frame as Transition.  If ``True``, treat the last
         frame as the start of a state transition.  Has no effect if
         `pin` is set to ``"end"``.  Must not be used together with
-        `trans_type`, `wrap` or `mic`.
+        `discard_neg`, `trans_type`, `wrap` or `mic`.
     mic : bool, optional
         If ``True``, respect the Minimum Image Convention when
         evaluating the transition type, i.e. when evaluating whether the
@@ -190,6 +197,7 @@ iterable of ints, optional
         a=dtrj,
         axis=axis,
         pin=pin,
+        discard_neg=discard_neg,
         change_type=trans_type,
         rtol=0,
         atol=0,

--- a/src/mdtools/dtrj.py
+++ b/src/mdtools/dtrj.py
@@ -1958,7 +1958,7 @@ def remain_prob(  # noqa: C901
 
     This means transitions from or to negative states are completely
     discarded.  Thus, the resulting probability does neither contain the
-    probability to stay in a negative state nor is it decreased by
+    probability to stay in a negative state nor is it affected by
     transitions from positive to negative states.
 
     **Lifetimes**

--- a/src/mdtools/dtrj.py
+++ b/src/mdtools/dtrj.py
@@ -1448,18 +1448,21 @@ def lifetimes_per_state(
         interpreted as the indices of the states in which a given
         compound is at a given frame.
     discard_neg_start : bool, optional
-        If ``True``, discard the lifetimes of all negative states.  This
-        is equivalent to discarding all transitions starting from a
-        negative state when calculating the remain probability with
-        :func:`mdtools.dtrj.remain_prob` or
-        :func:`mdtools.dtrj.remain_prob_discrete`.  Has no effect if
-        `discard_all_neg` is ``True``.
+        If ``True``, discard the lifetimes of all negative states (see
+        notes of :func:`mdtools.dtrj.lifetimes`).  This is equivalent to
+        discarding all transitions starting from a negative state when
+        calculating transition rates with
+        :func:`mdtools.dtrj.trans_rate_per_state` or remain
+        probabilities with :func:`mdtools.dtrj.remain_prob_discrete`.
+        Has no effect if `discard_all_neg` is ``True``.
     discard_all_neg : bool, optional
         If ``True``, discard the lifetimes of all negative states and of
-        all states that are followed by a negative state.  This is
-        equivalent to discarding all negative states when calculating
-        the remain probability with :func:`mdtools.dtrj.remain_prob` or
-        :func:`mdtools.dtrj.remain_prob_discrete`.
+        all states that are followed by a negative state (see notes of
+        :func:`mdtools.dtrj.lifetimes`).  This is equivalent to
+        discarding all transitions starting from or ending in a negative
+        state when calculating transition rates with
+        :func:`mdtools.dtrj.trans_rate_per_state` or remain
+        probabilities with :func:`mdtools.dtrj.remain_prob_discrete`.
     return_states : bool, optional
         If ``True``, return the state indices associated with the
         returned lifetimes.
@@ -1507,6 +1510,9 @@ def lifetimes_per_state(
         Calculate the lifetimes for all compounds in all states of a
         discrete trajectory by simply counting the number of frames a
         given compound stays in a given state
+    :func:`mdtools.dtrj.trans_rate_per_state` :
+        Calculate the transition rate for each state averaged over all
+        compounds
     :func:`mdtools.dtrj.remain_prob_discrete` :
         Calculate the probability that a compound is in the same state
         as at time :math:`t_0` after a lag time :math:`\Delta t`
@@ -2277,12 +2283,19 @@ def remain_prob_discrete(  # noqa: C901
         :func:`mdtools.dtrj.remain_prob`).
     discard_neg_start : bool, optional
         If ``True``, discard all transitions starting from a negative
-        state (see notes of :func:`mdtools.dtrj.remain_prob`).  Must not
-        be used together with `discard_all_neg`.
+        state (see notes of :func:`mdtools.dtrj.remain_prob`).  This is
+        equivalent to discarding the lifetimes of all negative states
+        when calculating state lifetimes with
+        :func:`mdtools.dtrj.lifetimes_per_state`.  Must not be used
+        together with `discard_all_neg`.
     discard_all_neg : bool, optional
-        If ``True``, discard all negative states (see notes of
-        :func:`mdtools.dtrj.remain_prob`).  Must not be used together
-        with `discard_neg_start`.
+        If ``True``, discard all transitions starting from or ending in
+        a negative state (see notes of
+        :func:`mdtools.dtrj.remain_prob`).  This is equivalent to
+        discarding the lifetimes of all negative states and of all
+        states that are followed by a negative state when calculating
+        state lifetimes with :func:`mdtools.dtrj.lifetimes_per_state`.
+        Must not be used together with `discard_neg_start`.
     verbose : bool, optional
         If ``True`` print a progress bar.
 
@@ -2301,6 +2314,9 @@ def remain_prob_discrete(  # noqa: C901
     :func:`mdtools.dtrj.remain_prob` :
         Calculate the probability that a compound is in the same state
         as at time :math:`t_0` after a lag time :math:`\Delta t`
+    :func:`mdtools.dtrj.trans_rate_per_state` :
+        Calculate the transition rate for each state averaged over all
+        compounds
     :func:`mdtools.dtrj.lifetimes_per_state` :
         Calculate the lifetime of each state in a discrete trajectory by
         simply counting the number of frames a given compound stays in a

--- a/src/mdtools/dtrj.py
+++ b/src/mdtools/dtrj.py
@@ -896,6 +896,136 @@ mdt.dtrj.trans_per_state_vs_time(
         return hist
 
 
+def trans_rate(
+    dtrj,
+    axis=-1,
+    discard_neg_start=False,
+    discard_all_neg=False,
+    return_cmp_ix=False,
+):
+    """
+    Calculate the transition rate for each compound in a discrete
+    trajectory averaged over all states.
+
+    Parameters
+    ----------
+    dtrj : array_like
+        The discrete trajectory for which to calculate the transition
+        rates.
+    axis : int
+        The axis along which to search for state transitions.  For
+        ordinary discrete trajectories with shape ``(n, f)`` or
+        ``(f,)``, where ``n`` is the number of compounds and ``f`` is
+        the number of frames, set `axis` to ``-1``.  If you parse a
+        transposed discrete trajectory of shape ``(f, n)``, set `axis`
+        to ``0``.
+    discard_neg_start : bool, optional
+        If ``True``, discard all transitions starting from a negative
+        state (see notes).  This is equivalent to discarding the
+        lifetimes of all negative states when calculating state
+        lifetimes with :func:`mdtools.dtrj.lifetimes`.  Has no effect if
+        `discard_all_neg` is ``True``.
+    discard_all_neg : bool, optional
+        If ``True``, discard all transitions starting from or ending in
+        a negative state (see notes).  This is equivalent to discarding
+        the lifetimes of all negative states and of all states that are
+        followed by a negative state when calculating state lifetimes
+        with :func:`mdtools.dtrj.lifetimes`.
+    return_cmp_ix : bool, optional
+        If ``True``, return the compound indices associated with the
+        returned transition rates.
+
+    Returns
+    -------
+    trans_rate : numpy.ndarray
+        1-dimensional array containing the transition rate for each
+        averaged over all states.
+    cmp_ix : numpy.ndarray
+        1-dimensional array of the same shape as `trans_rate` containing
+        the corresponding compound indices.  Only returned if
+        `return_cmp_ix` is ``True``.
+
+    Notes
+    -----
+    Transitions rates are calculated by simply counting the number of
+    transitions and dividing by the total number of frames.
+
+    The inverse of the transition rate gives an estimate for the average
+    state lifetime.  In contrast to calculating the average lifetime by
+    simply counting how many frames a given compound stays in a given
+    state (as done by :func:`mdtools.dtrj.lifetimes`), this method is
+    not biased to lower lifetimes.
+
+    Examples
+    --------
+    >>> dtrj = np.array([[1, 2, 2, 3, 3, 3],
+    ...                  [2, 2, 3, 3, 3, 1],
+    ...                  [3, 3, 3, 1, 2, 2],
+    ...                  [1, 3, 3, 3, 2, 2]])
+    >>> rate = mdt.dtrj.trans_rate(dtrj)
+    0.3333333333333333  # 4 * 2 / (4 * 6)
+
+    >>> dtrj = np.array([[ 1, -2, -2,  3,  3,  3],
+    ...                  [-2, -2,  3,  3,  3,  1],
+    ...                  [ 3,  3,  3,  1, -2, -2],
+    ...                  [ 1,  3,  3,  3, -2, -2],
+    ...                  [ 1,  4,  4,  4,  4, -1]])
+    """
+    dtrj = mdt.check.dtrj(dtrj)
+    ax_cmp, ax_fr = mdt.dtrj.get_ax(ax_fr=axis)
+    n_frames = dtrj.shape[ax_fr]
+
+    # Get compounds that never leave their state.
+    dtrj_t0 = mdt.nph.take(dtrj, start=0, stop=1, axis=ax_fr)
+    cmp_ix_stay = np.flatnonzero(np.all(dtrj == dtrj_t0, axis=ax_fr))
+    del dtrj_t0
+
+    # Get all state transitions.
+    trans_ix_start = mdt.dtrj.trans_ix(dtrj, axis=ax_fr, pin="start")
+    if discard_neg_start:
+        valid = dtrj[trans_ix_start] >= 0
+        if discard_all_neg:
+            trans_ix_end = np.copy(trans_ix_start)
+            trans_ix_end[ax_fr] += 1
+            trans_ix_end = tuple(trans_ix_end)
+            valid &= dtrj[trans_ix_end] >= 0
+            del trans_ix_end
+        trans_ix_start = tuple(t_ix[valid] for t_ix in trans_ix_start)
+        # Remove compounds that are always in a negative state from the
+        # list of compounds that never leave their state.
+        cmp_ix_always_neg = np.flatnonzero(np.all(dtrj < 0, axis=ax_fr))
+        cmp_ix_stay = np.setdiff1d(
+            cmp_ix_stay, cmp_ix_always_neg, assume_unique=True
+        )
+        del cmp_ix_always_neg
+    del dtrj
+
+    # Get number of transitions per compound.
+    cmp_ix, trans_per_cmp = mdt.nph.group_by(
+        trans_ix_start[ax_cmp], trans_ix_start[ax_fr], return_keys=True
+    )
+    if np.any(np.isin(cmp_ix_stay, cmp_ix, assume_unique=True)):
+        raise ValueError(
+            "At least one compound changes and stays in its state at the same"
+            " time.  This should not have happened."
+        )
+    cmp_ix = np.append(cmp_ix, cmp_ix_stay)
+    trans_per_cmp = np.array([len(trans_ix) for trans_ix in trans_per_cmp])
+    trans_per_cmp = np.append(trans_per_cmp, [0 for cmp_stay in cmp_ix_stay])
+
+    # Sort by compound index.
+    sort_ix = np.argsort(cmp_ix)
+    cmp_ix = cmp_ix[sort_ix]
+    trans_per_cmp = trans_per_cmp[sort_ix]
+
+    # Calculate transition rates.
+    trans_rate_per_cmp = trans_per_cmp / n_frames
+    if return_cmp_ix:
+        return trans_rate_per_cmp, cmp_ix
+    else:
+        return trans_rate_per_cmp
+
+
 def lifetimes(
     dtrj,
     discard_neg_start=False,
@@ -924,18 +1054,19 @@ def lifetimes(
         interpreted as the indices of the states in which a given
         compound is at a given frame.
     discard_neg_start : bool, optional
-        If ``True``, discard the lifetimes of all negative states.  This
-        is equivalent to discarding all transitions starting from a
-        negative state when calculating the remain probability with
-        :func:`mdtools.dtrj.remain_prob` or
-        :func:`mdtools.dtrj.remain_prob_discrete`.  Has no effect if
+        If ``True``, discard the lifetimes of all negative states (see
+        notes).  This is equivalent to discarding all transitions
+        starting from a negative state when calculating transition rates
+        with :func:`mdtools.dtrj.trans_rate` or remain probabilities
+        with :func:`mdtools.dtrj.remain_prob`.  Has no effect if
         `discard_all_neg` is ``True``.
     discard_all_neg : bool, optional
         If ``True``, discard the lifetimes of all negative states and of
-        all states that are followed by a negative state.  This is
-        equivalent to discarding all negative states when calculating
-        the remain probability with :func:`mdtools.dtrj.remain_prob` or
-        :func:`mdtools.dtrj.remain_prob_discrete`.
+        all states that are followed by a negative state (see notes).
+        This is equivalent to discarding all transitions starting from
+        or ending in a negative state when calculating transition rates
+        with :func:`mdtools.dtrj.trans_rate` or remain probabilities
+        with :func:`mdtools.dtrj.remain_prob`.
     return_states : bool, optional
         If ``True``, return the state indices associated with the
         returned lifetimes.
@@ -1559,11 +1690,17 @@ def remain_prob(  # noqa: C901
         without interruption in order to be counted (see notes).
     discard_neg_start : bool, optional
         If ``True``, discard all transitions starting from a negative
-        state (see notes).  Must not be used together with
-        `discard_all_neg`.
+        state (see notes).  This is equivalent to discarding the
+        lifetimes of all negative states when calculating state
+        lifetimes with :func:`mdtools.dtrj.lifetimes`.  Must not be used
+        together with `discard_all_neg`.
     discard_all_neg : bool, optional
-        If ``True``, discard all negative states (see notes).  Must not
-        be used together with `discard_neg_start`.
+        If ``True``, discard all transitions starting from or ending in
+        a negative state (see notes).  This is equivalent to discarding
+        the lifetimes of all negative states and of all states that are
+        followed by a negative state when calculating state lifetimes
+        with :func:`mdtools.dtrj.lifetimes`.  Must not be used together
+        with `discard_neg_start`.
     verbose : bool, optional
         If ``True`` print a progress bar.
 

--- a/src/mdtools/dtrj.py
+++ b/src/mdtools/dtrj.py
@@ -33,6 +33,84 @@ import psutil
 import mdtools as mdt
 
 
+def get_ax(ax_cmp=None, ax_fr=None):
+    """
+    Return the frame/compound axis for a discrete trajectory given its
+    compound/frame axis.
+
+    Parameters
+    ----------
+    ax_cmp : {-2, -1, 0, 1} or None, optional
+        Compound axis.  Either `ax_cmp` or `ax_fr` must be given.
+    ax_fr : {-2, -1, 0, 1} or None, optional
+        Frame axis.  Either `ax_cmp` or `ax_fr` must be given.
+
+    Returns
+    -------
+    ax_cmp : int
+        The compound axis for a discrete trajectory.
+    ax_fr : int
+        The frame axis for a discrete trajectory.
+
+    Raises
+    ------
+    :exc:`numpy.exceptions.AxisError` :
+        If the given compound/frame axis is out of bounds for a discrete
+        trajectory with two dimensions.
+
+    Notes
+    -----
+    All returned axis indices will be positive.
+
+    Examples
+    --------
+    >>> mdt.dtrj.get_ax(ax_cmp=0)
+    (0, 1)
+    >>> mdt.dtrj.get_ax(ax_cmp=1)
+    (1, 0)
+    >>> mdt.dtrj.get_ax(ax_cmp=-1)
+    (1, 0)
+    >>> mdt.dtrj.get_ax(ax_cmp=-2)
+    (0, 1)
+
+    >>> mdt.dtrj.get_ax(ax_fr=0)
+    (1, 0)
+    >>> mdt.dtrj.get_ax(ax_fr=1)
+    (0, 1)
+    >>> mdt.dtrj.get_ax(ax_fr=-1)
+    (0, 1)
+    >>> mdt.dtrj.get_ax(ax_fr=-2)
+    (1, 0)
+    """
+    ax_is_none = [ax is None for ax in (ax_cmp, ax_fr)]
+    if all(ax_is_none) or not any(ax_is_none):
+        raise ValueError(
+            "Either `ax_fr` ({}) or `ax_cmp` ({}) must be"
+            " given".format(ax_fr, ax_cmp)
+        )
+
+    dtrj_ndim = 2
+    axis = ax_cmp if ax_cmp is not None else ax_fr
+    if axis >= dtrj_ndim or axis < -dtrj_ndim:
+        raise np.AxisError(
+            axis=axis, ndim=dtrj_ndim, msg_prefix="Discrete trajectory"
+        )
+
+    dtrj_axes = list(range(dtrj_ndim))
+    if ax_cmp is not None:
+        compound_axis = dtrj_axes.pop(ax_cmp)
+        frame_axis = dtrj_axes[0]
+    elif ax_fr is not None:
+        frame_axis = dtrj_axes.pop(ax_fr)
+        compound_axis = dtrj_axes[0]
+    else:
+        raise ValueError(
+            "Either `ax_fr` ({}) or `ax_cmp` ({}) must be"
+            " given".format(ax_fr, ax_cmp)
+        )
+    return compound_axis, frame_axis
+
+
 def locate_trans(
     dtrj,
     axis=-1,

--- a/src/mdtools/dtrj.py
+++ b/src/mdtools/dtrj.py
@@ -1523,6 +1523,7 @@ def lifetimes(
 
 def lifetimes_per_state(
     dtrj,
+    axis=-1,
     discard_neg_start=False,
     discard_all_neg=False,
     return_states=False,
@@ -1538,12 +1539,14 @@ def lifetimes_per_state(
     Parameters
     ----------
     dtrj : array_like
-        The discrete trajectory.  Array of shape ``(n, f)``, where ``n``
-        is the number of compounds and ``f`` is the number of frames.
-        The shape can also be ``(f,)``, in which case the array is
-        expanded to shape ``(1, f)``.   The elements of `dtrj` are
-        interpreted as the indices of the states in which a given
-        compound is at a given frame.
+        Array containing the discrete trajectory.
+    axis : int, optional
+        The axis along which to search for state transitions.  For
+        ordinary discrete trajectories with shape ``(n, f)`` or
+        ``(f,)``, where ``n`` is the number of compounds and ``f`` is
+        the number of frames, set `axis` to ``-1``.  If you parse a
+        transposed discrete trajectory of shape ``(f, n)``, set `axis`
+        to ``0``.
     discard_neg_start : bool, optional
         If ``True``, discard the lifetimes of all negative states (see
         notes of :func:`mdtools.dtrj.lifetimes`).  This is equivalent to
@@ -1652,6 +1655,24 @@ def lifetimes_per_state(
     array([1., 2., 3.])
     >>> lt_std
     array([0., 0., 0.])
+    >>> lt, states, cmp_ix, lt_avg, lt_std = mdt.dtrj.lifetimes_per_state(
+    ...     dtrj,
+    ...     axis=0,
+    ...     return_states=True,
+    ...     return_cmp_ix=True,
+    ...     return_avg=True,
+    ...     return_std=True,
+    ... )
+    >>> lt
+    [array([1, 1, 1, 1]), array([1, 2, 1, 2, 2]), array([1, 2, 3, 2, 1, 2, 1])]
+    >>> states
+    array([1, 2, 3])
+    >>> cmp_ix
+    [array([0, 0, 3, 5]), array([0, 1, 2, 4, 5]), array([0, 1, 2, 3, 3, 4, 5])]
+    >>> lt_avg
+    array([1.        , 1.6       , 1.71428571])
+    >>> lt_std
+    array([0.        , 0.48989795, 0.69985421])
 
     >>> dtrj = np.array([[1, 2, 2, 3, 3, 3],
     ...                  [2, 2, 3, 3, 3, 1],
@@ -1674,6 +1695,24 @@ def lifetimes_per_state(
     array([1., 2., 3., 2., 3.])
     >>> lt_std
     array([0., 0., 0., 0., 0.])
+    >>> lt, states, cmp_ix, lt_avg, lt_std = mdt.dtrj.lifetimes_per_state(
+    ...     dtrj,
+    ...     axis=0,
+    ...     return_states=True,
+    ...     return_cmp_ix=True,
+    ...     return_avg=True,
+    ...     return_std=True,
+    ... )
+    >>> lt
+    [array([1, 1, 1, 1]), array([1, 2, 1]), array([1, 2, 2, 1]), array([2, 2]), array([1, 2, 2, 1])]
+    >>> states
+    array([1, 2, 3, 4, 6])
+    >>> cmp_ix
+    [array([0, 0, 3, 5]), array([0, 1, 2]), array([2, 3, 4, 5]), array([4, 5]), array([0, 1, 2, 3])]
+    >>> lt_avg
+    array([1.        , 1.33333333, 1.5       , 2.        , 1.5       ])
+    >>> lt_std
+    array([0.        , 0.47140452, 0.5       , 0.        , 0.5       ])
 
     >>> dtrj = np.array([[ 1,  2,  2,  1,  1,  1],
     ...                  [ 2,  2,  3,  3,  3,  2],
@@ -1733,6 +1772,65 @@ def lifetimes_per_state(
     array([2. , 1.6, 3. ])
     >>> lt_std
     array([1.        , 0.48989795, 0.        ])
+    >>> ax = 0
+    >>> lt, states, cmp_ix, lt_avg, lt_std = mdt.dtrj.lifetimes_per_state(
+    ...     dtrj,
+    ...     axis=ax,
+    ...     return_states=True,
+    ...     return_cmp_ix=True,
+    ...     return_avg=True,
+    ...     return_std=True,
+    ... )
+    >>> lt
+    [array([1, 1, 1]), array([1, 1]), array([1]), array([1, 1, 1, 1]), array([1, 1, 2, 1, 1, 2]), array([1, 1, 1, 1, 1, 1])]
+    >>> states
+    array([-3, -2, -1,  1,  2,  3])
+    >>> cmp_ix
+    [array([0, 1, 2]), array([4, 5]), array([3]), array([0, 3, 4, 5]), array([0, 0, 1, 2, 4, 5]), array([1, 2, 2, 3, 3, 4])]
+    >>> lt_avg
+    array([1.        , 1.        , 1.        , 1.        , 1.33333333,
+           1.        ])
+    >>> lt_std
+    array([0.        , 0.        , 0.        , 0.        , 0.47140452,
+           0.        ])
+    >>> lt, states, cmp_ix, lt_avg, lt_std = mdt.dtrj.lifetimes_per_state(
+    ...     dtrj,
+    ...     axis=ax,
+    ...     discard_neg_start=True,
+    ...     return_states=True,
+    ...     return_cmp_ix=True,
+    ...     return_avg=True,
+    ...     return_std=True,
+    ... )
+    >>> lt
+    [array([1, 1, 1, 1]), array([1, 1, 2, 1, 1, 2]), array([1, 1, 1, 1, 1, 1])]
+    >>> states
+    array([1, 2, 3])
+    >>> cmp_ix
+    [array([0, 3, 4, 5]), array([0, 0, 1, 2, 4, 5]), array([1, 2, 2, 3, 3, 4])]
+    >>> lt_avg
+    array([1.        , 1.33333333, 1.        ])
+    >>> lt_std
+    array([0.        , 0.47140452, 0.        ])
+    >>> lt, states, cmp_ix, lt_avg, lt_std = mdt.dtrj.lifetimes_per_state(
+    ...     dtrj,
+    ...     axis=ax,
+    ...     discard_all_neg=True,
+    ...     return_states=True,
+    ...     return_cmp_ix=True,
+    ...     return_avg=True,
+    ...     return_std=True,
+    ... )
+    >>> lt
+    [array([1, 1, 1, 1]), array([1, 1]), array([1, 1, 1, 1])]
+    >>> states
+    array([1, 2, 3])
+    >>> cmp_ix
+    [array([0, 3, 4, 5]), array([0, 2]), array([1, 2, 3, 4])]
+    >>> lt_avg
+    array([1., 1., 1.])
+    >>> lt_std
+    array([0., 0., 0.])
 
     >>> dtrj = np.array([[ 1, -2, -2,  3,  3,  3],
     ...                  [-2, -2,  3,  3,  3,  1],
@@ -1792,9 +1890,67 @@ def lifetimes_per_state(
     array([1., 3.])
     >>> lt_std
     array([0., 0.])
+    >>> ax = 0
+    >>> lt, states, cmp_ix, lt_avg, lt_std = mdt.dtrj.lifetimes_per_state(
+    ...     dtrj,
+    ...     axis=ax,
+    ...     return_states=True,
+    ...     return_cmp_ix=True,
+    ...     return_avg=True,
+    ...     return_std=True,
+    ... )
+    >>> lt
+    [array([1, 2, 1, 2, 2]), array([1]), array([1, 2, 1, 1]), array([1, 2, 3, 2, 1, 2, 1]), array([1, 1, 1, 1])]
+    >>> states
+    array([-2, -1,  1,  3,  4])
+    >>> cmp_ix
+    [array([0, 1, 2, 4, 5]), array([5]), array([0, 0, 3, 5]), array([0, 1, 2, 3, 3, 4, 5]), array([1, 2, 3, 4])]
+    >>> lt_avg
+    array([1.6       , 1.        , 1.25      , 1.71428571, 1.        ])
+    >>> lt_std
+    array([0.48989795, 0.        , 0.4330127 , 0.69985421, 0.        ])
+    >>> lt, states, cmp_ix, lt_avg, lt_std = mdt.dtrj.lifetimes_per_state(
+    ...     dtrj,
+    ...     axis=ax,
+    ...     discard_neg_start=True,
+    ...     return_states=True,
+    ...     return_cmp_ix=True,
+    ...     return_avg=True,
+    ...     return_std=True,
+    ... )
+    >>> lt
+    [array([1, 2, 1, 1]), array([1, 2, 3, 2, 1, 2, 1]), array([1, 1, 1, 1])]
+    >>> states
+    array([1, 3, 4])
+    >>> cmp_ix
+    [array([0, 0, 3, 5]), array([0, 1, 2, 3, 3, 4, 5]), array([1, 2, 3, 4])]
+    >>> lt_avg
+    array([1.25      , 1.71428571, 1.        ])
+    >>> lt_std
+    array([0.4330127 , 0.69985421, 0.        ])
+    >>> lt, states, cmp_ix, lt_avg, lt_std = mdt.dtrj.lifetimes_per_state(
+    ...     dtrj,
+    ...     axis=ax,
+    ...     discard_all_neg=True,
+    ...     return_states=True,
+    ...     return_cmp_ix=True,
+    ...     return_avg=True,
+    ...     return_std=True,
+    ... )
+    >>> lt
+    [array([2, 1]), array([1, 2, 3, 2, 1, 1]), array([1, 1, 1, 1])]
+    >>> states
+    array([1, 3, 4])
+    >>> cmp_ix
+    [array([0, 3]), array([0, 1, 2, 3, 3, 5]), array([1, 2, 3, 4])]
+    >>> lt_avg
+    array([1.5       , 1.66666667, 1.        ])
+    >>> lt_std
+    array([0.5       , 0.74535599, 0.        ])
     """  # noqa: E501, W505
     lt, states, cmp_ix = mdt.dtrj.lifetimes(
         dtrj,
+        axis=axis,
         discard_neg_start=discard_neg_start,
         discard_all_neg=discard_all_neg,
         return_states=True,

--- a/src/mdtools/dtrj.py
+++ b/src/mdtools/dtrj.py
@@ -214,6 +214,7 @@ def trans_ix(
     dtrj,
     axis=-1,
     pin="end",
+    discard_neg=None,
     trans_type=None,
     wrap=False,
     tfft=False,
@@ -233,6 +234,8 @@ def trans_ix(
     axis : int
         See :func:`mdtools.dtrj.locate_trans`.
     pin : {"end", "start", "both"}
+        See :func:`mdtools.dtrj.locate_trans`.
+    discard_neg : {None, "start", "end", "both"}, optional
         See :func:`mdtools.dtrj.locate_trans`.
     trans_type : {None, "higher", "lower", "both"} or int or \
 iterable of ints, optional
@@ -301,6 +304,7 @@ iterable of ints, optional
         a=dtrj,
         axis=axis,
         pin=pin,
+        discard_neg=discard_neg,
         change_type=trans_type,
         rtol=0,
         atol=0,

--- a/src/mdtools/dtrj.py
+++ b/src/mdtools/dtrj.py
@@ -1142,9 +1142,7 @@ def lifetimes(
     See Also
     --------
     :func:`mdtools.dtrj.lifetimes_per_state` :
-        Calculate the lifetime of each state in a discrete trajectory by
-        simply counting the number of frames a given compound stays in a
-        given state
+        Calculate the state lifetimes for each state
     :func:`mdtools.dtrj.trans_rate` :
         Calculate the transition rate for each compound averaged over
         all states
@@ -1430,15 +1428,7 @@ def lifetimes_per_state(
     kwargs_std=None,
 ):
     r"""
-    Calculate the lifetime of each state in a discrete trajectory by
-    simply counting the number of frames a given compound stays in a
-    given state.
-
-    Note that lifetimes calculated in this way can at maximum be as long
-    as the trajectory and are usually biased to lower values because of
-    edge effects:  At the beginning and end of the trajectory it is
-    impossible to say how long a compound has already been it's initial
-    state or how long it will stay in it's final state.
+    Calculate the state lifetimes for each state.
 
     Parameters
     ----------
@@ -1521,6 +1511,16 @@ def lifetimes_per_state(
 
     Notes
     -----
+    State lifetimes are calculated by simply counting the number of
+    frames a given compound stays in a given state.  Note that lifetimes
+    calculated in this way can at maximum be as long as the trajectory
+    and are usually biased to lower values because of edge effects:  At
+    the beginning and end of the trajectory it is impossible to say how
+    long a compound has already been it's initial state or how long it
+    will stay in it's final state.  For unbiased estimates of the
+    average state lifetime use :func:`mdtools.dtrj.trans_rate_per_state`
+    or :func:`mdtools.dtrj.remain_prob_discrete`.
+
     See :func:`mdtools.dtrj.lifetimes` for details about valid and
     invalid states (`discard_neg_start` and `discard_all_neg`).
 
@@ -2316,9 +2316,7 @@ def remain_prob_discrete(  # noqa: C901
         Calculate the transition rate for each state averaged over all
         compounds
     :func:`mdtools.dtrj.lifetimes_per_state` :
-        Calculate the lifetime of each state in a discrete trajectory by
-        simply counting the number of frames a given compound stays in a
-        given state
+        Calculate the state lifetimes for each state
 
     Notes
     -----

--- a/src/mdtools/dtrj.py
+++ b/src/mdtools/dtrj.py
@@ -931,7 +931,7 @@ def trans_rate(dtrj, return_cmp_ix=False, **kwargs):
         Calculate the probability that a compound is in the same state
         as at time :math:`t_0` after a lag time :math:`\Delta t`
     :func:`mdtools.dtrj.lifetimes` :
-        Calculate the state lifetimes for all compounds
+        Calculate the state lifetimes for each compound
 
     Notes
     -----
@@ -1093,15 +1093,7 @@ def lifetimes(
     return_cmp_ix=False,
 ):
     r"""
-    Calculate the lifetimes for all compounds in all states of a
-    discrete trajectory by simply counting the number of frames a given
-    compound stays in a given state.
-
-    Note that lifetimes calculated in this way can at maximum be as long
-    as the trajectory and are usually biased to lower values because of
-    edge effects:  At the beginning and end of the trajectory it is
-    impossible to say how long a compound has already been it's initial
-    state or how long it will stay in it's final state.
+    Calculate the state lifetimes for each compound.
 
     Parameters
     ----------
@@ -1162,6 +1154,16 @@ def lifetimes(
 
     Notes
     -----
+    State lifetimes are calculated by simply counting the number of
+    frames a given compound stays in a given state.  Note that lifetimes
+    calculated in this way can at maximum be as long as the trajectory
+    and are usually biased to lower values because of edge effects:  At
+    the beginning and end of the trajectory it is impossible to say how
+    long a compound has already been it's initial state or how long it
+    will stay in it's final state.  For unbiased estimates of the
+    average state lifetime use :func:`mdtools.dtrj.trans_rate` or
+    :func:`mdtools.dtrj.remain_prob`.
+
     **Valid and Invalid States**
 
     (See also the notes of :func:`mdtools.dtrj.remain_prob`.)
@@ -1507,9 +1509,7 @@ def lifetimes_per_state(
     See Also
     --------
     :func:`mdtools.dtrj.lifetimes` :
-        Calculate the lifetimes for all compounds in all states of a
-        discrete trajectory by simply counting the number of frames a
-        given compound stays in a given state
+        Calculate the state lifetimes for each compound
     :func:`mdtools.dtrj.trans_rate_per_state` :
         Calculate the transition rate for each state averaged over all
         compounds
@@ -1790,9 +1790,7 @@ def remain_prob(  # noqa: C901
         Calculate the transition rate for each compound averaged over
         all states
     :func:`mdtools.dtrj.lifetimes` :
-        Calculate the lifetimes for all compounds in all states of a
-        discrete trajectory by simply counting the number of frames a
-        given compound stays in a given state
+        Calculate the state lifetimes for each compound
 
     Notes
     -----

--- a/src/mdtools/numpy_helper_functions.py
+++ b/src/mdtools/numpy_helper_functions.py
@@ -2736,26 +2736,27 @@ array([], shape=(2, 0), dtype=bool))
             )
 
     if mic:
-        # Boundaries for the minimum image convention
-        # (Don't remove, also needed further below)
+        # Boundaries for the minimum image convention.
+        # (Don't remove, also needed further below.)
         amin = np.min(a) if amin is None else amin
         amax = np.max(a) if amax is None else amax
-        # Item differences according to the minimum image convention
+        # Item differences according to the minimum image convention.
         item_diffs = mdt.nph.diff_mic(a, amin=amin, amax=amax, axis=axis)
     else:
         if change_type is not None and np.issubdtype(
             a.dtype, np.unsignedinteger
         ):
-            # np.diff keeps the dtype of the input array => If the dtype
-            # of the input array is an unsigned integer type, negative
-            # differences are not possible.
+            # `np.diff` keeps the dtype of the input array => If the
+            # dtype of the input array is an unsigned integer type,
+            # negative differences are not possible.
             a = a.astype(np.int64, casting="safe")
+        # Simple item differences.
         item_diffs = np.diff(a, axis=axis)
-    if change_type is None:  # All changes
+    if change_type is None:  # All changes.
         operators = (np.not_equal,)
-    elif change_type == "higher":  # Changes to higher values
+    elif change_type == "higher":  # Changes to higher values.
         operators = (np.greater,)
-    elif change_type == "lower":  # Changes to lower values
+    elif change_type == "lower":  # Changes to lower values.
         operators = (np.less,)
     elif change_type == "both":  # Changes to higher and to lower values
         operators = (np.greater, np.less)
@@ -2776,26 +2777,28 @@ array([], shape=(2, 0), dtype=bool))
                     "`change_type` ({}) must not be an empty"
                     " iterable".format(change_type)
                 )
-        except TypeError:  # change_type is not iterable
+        except TypeError:  # `change_type` is not iterable.
             operators = (lambda x, _: np.isclose(x, change_type, rtol, atol),)
+    # Tuple of boolean arrays that indicate the positions of item
+    # changes.
     items_changed = tuple(op(item_diffs, 0) for op in operators)
 
-    # Only index `a.shape` with `axis` after np.diff(a, axis) to get a
-    # proper numpy.AxisError if `axis` is out of bounds (instead of an
-    # IndexError)
+    # Only index `a.shape` with `axis` after `np.diff(a, axis)` to get a
+    # proper `numpy.AxisError`` if `axis` is out of bounds (instead of
+    # an `IndexError`).
     if a.shape[axis] == 0:
         item_change = np.zeros_like(a, dtype=bool)
         if len(items_changed) > 1:
             item_change = tuple(item_change for itm_chngd in items_changed)
-        if pin == "both":  # equivalent to `pin` = before *and* after
+        if pin == "both":  # equivalent to `pin` = before *and* after.
             return item_change, item_change
-        else:  # `pin` = before *or* after
+        else:  # `pin` = before *or* after.
             return item_change
 
     # Construct an insertion array which will be inserted after or
-    # before `items_changed` to bring `items_changed` to the same shape
-    # as `a` and make `items_changed` a mask for items of `a` which are
-    # right before or right after an item change.
+    # before the arrays in `items_changed` to bring them to the same
+    # shape as the input array `a` and make them a mask for items of `a`
+    # which are right before or right after an item change.
     shape = list(item_diffs.shape)
     shape[axis] = 1
     shape = tuple(shape)
@@ -2833,7 +2836,7 @@ array([], shape=(2, 0), dtype=bool))
     del item_diffs, operators
 
     if pin in ("before", "both"):
-        # Items of `a` right before an item change
+        # Items of `a` right before an item change.
         item_change_before = [
             np.zeros(a.shape, dtype=bool) for itm_chngd in items_changed
         ]
@@ -2848,7 +2851,7 @@ array([], shape=(2, 0), dtype=bool))
         if pin == "before":
             return item_change_before
     if pin in ("after", "both"):
-        # Items of `a` right after an item change
+        # Items of `a` right after an item change.
         item_change_after = [
             np.zeros(a.shape, dtype=bool) for itm_chngd in items_changed
         ]

--- a/src/mdtools/numpy_helper_functions.py
+++ b/src/mdtools/numpy_helper_functions.py
@@ -3586,7 +3586,7 @@ array([], shape=(2, 0), dtype=bool))
     return item_change_before, item_change_after
 
 
-def item_change_ix(a, discard_neg=None, **kwargs):
+def item_change_ix(a, **kwargs):
     """
     Get the indices of item changes in an array.
 
@@ -3594,18 +3594,6 @@ def item_change_ix(a, discard_neg=None, **kwargs):
     ----------
     a : array_like
         Array for which to get all indices where its elements change.
-    discard_neg : {None, "start", "end", "both"}, optional
-        Whether to respect all item changes (``None``) or whether to
-        discard item changes starting from a negative item (``"start"``)
-        or ending at a negative item (``"end"``).  If set to ``"both"``,
-        all item changes starting from or ending at a negative item will
-        be discarded.  Must not be used together with the keyword
-        arguments `wrap`, `tfic` or `tlic`.
-
-        .. todo::
-
-            Allow to use `discard_neg` together with `wrap`.
-
     kwargs : tuple, optional
         Additional keyword arguments to parse to
         :func:`mdtools.numpy_helper_functions.locate_item_change`.  See
@@ -3635,8 +3623,8 @@ def item_change_ix(a, discard_neg=None, **kwargs):
 
     Notes
     -----
-    This function basically just applies :func:`numpy.nonzero` to the
-    output of :func:`mdtools.numpy_helper_functions.locate_item_change`.
+    This function only applies :func:`numpy.nonzero` to the output of
+    :func:`mdtools.numpy_helper_functions.locate_item_change`.
 
     Examples
     --------
@@ -4329,48 +4317,88 @@ array([0, 1, 0, 2, 0, 2, 0, 1]))
     Examples for using `discard_neg`:
 
     >>> a = np.array([ 1, -2, -2,  3,  3,  3])
-    >>> before_disc_start, after_disc_start = mdt.nph.item_change_ix(
-    ...     a, discard_neg="start", pin="both"
-    ... )
-    >>> before_disc_start
-    (array([0]),)
-    >>> after_disc_start
-    (array([1]),)
-    >>> before_disc_end, after_disc_end = mdt.nph.item_change_ix(
-    ...     a, discard_neg="end", pin="both"
-    ... )
-    >>> before_disc_end
-    (array([2]),)
-    >>> after_disc_end
-    (array([3]),)
-    >>> before_disc_both, after_disc_both = mdt.nph.item_change_ix(
-    ...     a, discard_neg="both", pin="both"
-    ... )
-    >>> before_disc_both
-    (array([], dtype=int64),)
-    >>> after_disc_both
-    (array([], dtype=int64),)
-    >>> before_disc_start = mdt.nph.item_change_ix(
-    ...     a, discard_neg="start", pin="before"
-    ... )
-    >>> before_disc_start
-    (array([0]),)
-    >>> after_disc_end = mdt.nph.item_change_ix(
-    ...     a, discard_neg="end", pin="after"
-    ... )
-    >>> after_disc_end
-    (array([3]),)
-
-    >>> a = np.array([ 1, -2, -2,  3,  3,  3,  1])
     >>> before_start, after_start = mdt.nph.item_change_ix(
-    ...     a, discard_neg="start", pin="both"
+    ...     a, pin="both", discard_neg="start"
     ... )
     >>> before_start
-    (array([0, 5]),)
+    (array([0]),)
     >>> after_start
-    (array([1, 6]),)
+    (array([1]),)
+    >>> before_end, after_end = mdt.nph.item_change_ix(
+    ...     a, pin="both", discard_neg="end"
+    ... )
+    >>> before_end
+    (array([2]),)
+    >>> after_end
+    (array([3]),)
+    >>> before_both, after_both = mdt.nph.item_change_ix(
+    ...     a, pin="both", discard_neg="both"
+    ... )
+    >>> before_both
+    (array([], dtype=int64),)
+    >>> after_both
+    (array([], dtype=int64),)
+    >>> before_start = mdt.nph.item_change_ix(
+    ...     a, pin="before", discard_neg="start"
+    ... )
+    >>> before_start
+    (array([0]),)
+    >>> after_end = mdt.nph.item_change_ix(
+    ...     a, pin="after", discard_neg="end"
+    ... )
+    >>> after_end
+    (array([3]),)
     >>> before_end_type, after_end_type = mdt.nph.item_change_ix(
-    ...     a, discard_neg="end", pin="both", change_type="both"
+    ...     a, pin="both", discard_neg="end", change_type="both"
+    ... )
+    >>> before_end_type[0]  # Changes to higher values
+    (array([2]),)
+    >>> before_end_type[1]  # Changes to lower values
+    (array([], dtype=int64),)
+    >>> after_end_type[0]  # Changes to higher values
+    (array([3]),)
+    >>> after_end_type[1]  # Changes to lower values
+    (array([], dtype=int64),)
+    >>> before_start_wrap, after_start_wrap = mdt.nph.item_change_ix(
+    ...     a, pin="both", discard_neg="start", wrap=True
+    ... )
+    >>> before_start_wrap
+    (array([0, 5]),)
+    >>> after_start_wrap
+    (array([0, 1]),)
+    >>> before_end_type_w, after_end_type_w = mdt.nph.item_change_ix(
+    ...     a,
+    ...     pin="both",
+    ...     discard_neg="end",
+    ...     change_type="both",
+    ...     wrap=True,
+    ... )
+    >>> before_end_type_w[0]  # Changes to higher values
+    (array([2]),)
+    >>> before_end_type_w[1]  # Changes to lower values
+    (array([5]),)
+    >>> after_end_type_w[0]  # Changes to higher values
+    (array([3]),)
+    >>> after_end_type_w[1]  # Changes to lower values
+    (array([0]),)
+    >>> before_both_wrap, after_both_wrap = mdt.nph.item_change_ix(
+    ...     a, pin="both", discard_neg="both", wrap=True
+    ... )
+    >>> before_both_wrap
+    (array([5]),)
+    >>> after_both_wrap
+    (array([0]),)
+
+    >>> a = np.array([ 1, -2, -2,  3,  3,  3,  1])
+    >>> before_both, after_both = mdt.nph.item_change_ix(
+    ...     a, pin="both", discard_neg="both"
+    ... )
+    >>> before_both
+    (array([5]),)
+    >>> after_both
+    (array([6]),)
+    >>> before_end_type, after_end_type = mdt.nph.item_change_ix(
+    ...     a, pin="both", discard_neg="end", change_type="both"
     ... )
     >>> before_end_type[0]  # Changes to higher values
     (array([2]),)
@@ -4380,6 +4408,35 @@ array([0, 1, 0, 2, 0, 2, 0, 1]))
     (array([3]),)
     >>> after_end_type[1]
     (array([6]),)
+    >>> before_start_wrap, after_start_wrap = mdt.nph.item_change_ix(
+    ...     a, pin="both", discard_neg="start", wrap=True
+    ... )
+    >>> before_start_wrap
+    (array([0, 5]),)
+    >>> after_start_wrap
+    (array([1, 6]),)
+    >>> before_end_type_w, after_end_type_w = mdt.nph.item_change_ix(
+    ...     a,
+    ...     pin="both",
+    ...     discard_neg="end",
+    ...     change_type="both",
+    ...     wrap=True,
+    ... )
+    >>> before_end_type_w[0]  # Changes to higher values
+    (array([2]),)
+    >>> before_end_type_w[1]  # Changes to lower values
+    (array([5]),)
+    >>> after_end_type_w[0]
+    (array([3]),)
+    >>> after_end_type_w[1]
+    (array([6]),)
+    >>> before_both_wrap, after_both_wrap = mdt.nph.item_change_ix(
+    ...     a, pin="both", discard_neg="both", wrap=True
+    ... )
+    >>> before_both_wrap
+    (array([5]),)
+    >>> after_both_wrap
+    (array([6]),)
 
     2-dimensional example for using `discard_neg`:
 
@@ -4387,18 +4444,18 @@ array([0, 1, 0, 2, 0, 2, 0, 1]))
     ...               [ 3, -1,  3,  3],
     ...               [ 3,  3, -1,  3]])
     >>> ax = 0
-    >>> before_start, after_start = mdt.nph.item_change_ix(
-    ...     a, axis=ax, discard_neg="start", pin="both"
+    >>> before_both, after_both = mdt.nph.item_change_ix(
+    ...     a, axis=ax, pin="both", discard_neg="both"
     ... )
-    >>> before_start
-    (array([0, 1]), array([1, 2]))
-    >>> after_start
-    (array([1, 2]), array([1, 2]))
+    >>> before_both
+    (array([], dtype=int64), array([], dtype=int64))
+    >>> after_both
+    (array([], dtype=int64), array([], dtype=int64))
     >>> before_end_type, after_end_type = mdt.nph.item_change_ix(
     ...     a,
     ...     axis=ax,
-    ...     discard_neg="end",
     ...     pin="both",
+    ...     discard_neg="end",
     ...     change_type="both",
     ... )
     >>> before_end_type[0]  # Changes to higher values
@@ -4409,19 +4466,50 @@ array([0, 1, 0, 2, 0, 2, 0, 1]))
     (array([1, 2]), array([0, 1]))
     >>> after_end_type[1]
     (array([], dtype=int64), array([], dtype=int64))
-    >>> ax = 1
-    >>> before_start, after_start = mdt.nph.item_change_ix(
-    ...     a, axis=ax, discard_neg="start", pin="both"
+    >>> before_start_wrap, after_start_wrap = mdt.nph.item_change_ix(
+    ...     a, axis=ax, pin="both", discard_neg="start", wrap=True
     ... )
-    >>> before_start
-    (array([1, 2]), array([0, 1]))
-    >>> after_start
-    (array([1, 2]), array([1, 2]))
+    >>> before_start_wrap
+    (array([0, 1, 2]), array([1, 2, 0]))
+    >>> after_start_wrap
+    (array([0, 1, 2]), array([0, 1, 2]))
+    >>> before_end_type_w, after_end_type_w = mdt.nph.item_change_ix(
+    ...     a,
+    ...     axis=ax,
+    ...     pin="both",
+    ...     discard_neg="end",
+    ...     change_type="both",
+    ...     wrap=True,
+    ... )
+    >>> before_end_type_w[0]  # Changes to higher values
+    (array([0, 1, 2]), array([0, 1, 2]))
+    >>> before_end_type_w[1]  # Changes to lower values
+    (array([], dtype=int64), array([], dtype=int64))
+    >>> after_end_type_w[0]
+    (array([0, 1, 2]), array([2, 0, 1]))
+    >>> after_end_type_w[1]
+    (array([], dtype=int64), array([], dtype=int64))
+    >>> before_both_wrap, after_both_wrap = mdt.nph.item_change_ix(
+    ...     a, axis=ax, pin="both", discard_neg="both", wrap=True
+    ... )
+    >>> before_both_wrap
+    (array([], dtype=int64), array([], dtype=int64))
+    >>> after_both_wrap
+    (array([], dtype=int64), array([], dtype=int64))
+
+    >>> ax = 1
+    >>> before_both, after_both = mdt.nph.item_change_ix(
+    ...     a, axis=ax, pin="both", discard_neg="both"
+    ... )
+    >>> before_both
+    (array([], dtype=int64), array([], dtype=int64))
+    >>> after_both
+    (array([], dtype=int64), array([], dtype=int64))
     >>> before_end_type, after_end_type = mdt.nph.item_change_ix(
     ...     a,
     ...     axis=ax,
-    ...     discard_neg="end",
     ...     pin="both",
+    ...     discard_neg="end",
     ...     change_type="both",
     ... )
     >>> before_end_type[0]  # Changes to higher values
@@ -4432,6 +4520,36 @@ array([0, 1, 0, 2, 0, 2, 0, 1]))
     (array([0, 1, 2]), array([1, 2, 3]))
     >>> after_end_type[1]
     (array([], dtype=int64), array([], dtype=int64))
+    >>> before_start_wrap, after_start_wrap = mdt.nph.item_change_ix(
+    ...     a, axis=ax, pin="both", discard_neg="start", wrap=True
+    ... )
+    >>> before_start_wrap
+    (array([0, 1, 2]), array([3, 0, 1]))
+    >>> after_start_wrap
+    (array([0, 1, 2]), array([0, 1, 2]))
+    >>> before_end_type_w, after_end_type_w = mdt.nph.item_change_ix(
+    ...     a,
+    ...     axis=ax,
+    ...     pin="both",
+    ...     discard_neg="end",
+    ...     change_type="both",
+    ...     wrap=True,
+    ... )
+    >>> before_end_type_w[0]  # Changes to higher values
+    (array([0, 1, 2]), array([0, 1, 2]))
+    >>> before_end_type_w[1]  # Changes to lower values
+    (array([], dtype=int64), array([], dtype=int64))
+    >>> after_end_type_w[0]
+    (array([0, 1, 2]), array([1, 2, 3]))
+    >>> after_end_type_w[1]
+    (array([], dtype=int64), array([], dtype=int64))
+    >>> before_both_wrap, after_both_wrap = mdt.nph.item_change_ix(
+    ...     a, axis=ax, pin="both", discard_neg="both", wrap=True
+    ... )
+    >>> before_both_wrap
+    (array([], dtype=int64), array([], dtype=int64))
+    >>> after_both_wrap
+    (array([], dtype=int64), array([], dtype=int64))
 
     3-dimensional example for using `discard_neg`:
 
@@ -4441,18 +4559,18 @@ array([0, 1, 0, 2, 0, 2, 0, 1]))
     ...               [[ 2,  2,  1],
     ...                [-1,  2,  2]]])
     >>> ax = 0
-    >>> before_start, after_start = mdt.nph.item_change_ix(
-    ...     a, axis=ax, discard_neg="start", pin="both"
+    >>> before_both, after_both = mdt.nph.item_change_ix(
+    ...     a, axis=ax, pin="both", discard_neg="both"
     ... )
-    >>> before_start
-    (array([0, 0, 0]), array([0, 1, 1]), array([2, 0, 2]))
-    >>> after_start
-    (array([1, 1, 1]), array([0, 1, 1]), array([2, 0, 2]))
+    >>> before_both
+    (array([0, 0]), array([0, 1]), array([2, 2]))
+    >>> after_both
+    (array([1, 1]), array([0, 1]), array([2, 2]))
     >>> before_end_type, after_end_type = mdt.nph.item_change_ix(
     ...     a,
     ...     axis=ax,
-    ...     discard_neg="end",
     ...     pin="both",
+    ...     discard_neg="end",
     ...     change_type="both",
     ... )
     >>> before_end_type[0]  # Changes to higher values
@@ -4463,19 +4581,54 @@ array([0, 1, 0, 2, 0, 2, 0, 1]))
     (array([1, 1]), array([0, 1]), array([0, 2]))
     >>> after_end_type[1]
     (array([1]), array([0]), array([2]))
-    >>> ax = 1
-    >>> before_start, after_start = mdt.nph.item_change_ix(
-    ...     a, axis=ax, discard_neg="start", pin="both"
+    >>> before_start_wrap, after_start_wrap = mdt.nph.item_change_ix(
+    ...     a, axis=ax, pin="both", discard_neg="start", wrap=True
     ... )
-    >>> before_start
-    (array([0, 1, 1]), array([0, 0, 0]), array([2, 0, 2]))
-    >>> after_start
-    (array([0, 1, 1]), array([1, 1, 1]), array([2, 0, 2]))
+    >>> before_start_wrap
+    (array([0, 0, 0, 1, 1, 1]), \
+array([0, 1, 1, 0, 0, 1]), \
+array([2, 0, 2, 0, 2, 2]))
+    >>> after_start_wrap
+    (array([0, 0, 0, 1, 1, 1]), \
+array([0, 0, 1, 0, 1, 1]), \
+array([0, 2, 2, 2, 0, 2]))
+    >>> before_end_typ_w, after_end_typ_w = mdt.nph.item_change_ix(
+    ...     a,
+    ...     axis=ax,
+    ...     pin="both",
+    ...     discard_neg="end",
+    ...     change_type="both",
+    ...     wrap=True,
+    ... )
+    >>> before_end_typ_w[0]  # Changes to higher values
+    (array([0, 0, 1, 1]), array([0, 1, 0, 1]), array([0, 2, 2, 0]))
+    >>> before_end_typ_w[1]  # Changes to lower values
+    (array([0, 1]), array([0, 1]), array([2, 2]))
+    >>> after_end_typ_w[0]  # Changes to higher values
+    (array([0, 0, 1, 1]), array([0, 1, 0, 1]), array([2, 0, 0, 2]))
+    >>> after_end_typ_w[1]  # Changes to lower values
+    (array([0, 1]), array([1, 0]), array([2, 2]))
+    >>> before_both_wrap, after_both_wrap = mdt.nph.item_change_ix(
+    ...     a, axis=ax, pin="both", discard_neg="both", wrap=True
+    ... )
+    >>> before_both_wrap
+    (array([0, 0, 1, 1]), array([0, 1, 0, 1]), array([2, 2, 2, 2]))
+    >>> after_both_wrap
+    (array([0, 0, 1, 1]), array([0, 1, 0, 1]), array([2, 2, 2, 2]))
+
+    >>> ax = 1
+    >>> before_both, after_both = mdt.nph.item_change_ix(
+    ...     a, axis=ax, pin="both", discard_neg="both"
+    ... )
+    >>> before_both
+    (array([0, 1]), array([0, 0]), array([2, 2]))
+    >>> after_both
+    (array([0, 1]), array([1, 1]), array([2, 2]))
     >>> before_end_type, after_end_type = mdt.nph.item_change_ix(
     ...     a,
     ...     axis=ax,
-    ...     discard_neg="end",
     ...     pin="both",
+    ...     discard_neg="end",
     ...     change_type="both",
     ... )
     >>> before_end_type[0]  # Changes to higher values
@@ -4486,19 +4639,54 @@ array([0, 1, 0, 2, 0, 2, 0, 1]))
     (array([0, 1]), array([1, 1]), array([0, 2]))
     >>> after_end_type[1]
     (array([0]), array([1]), array([2]))
-    >>> ax = 2
-    >>> before_start, after_start = mdt.nph.item_change_ix(
-    ...     a, axis=ax, discard_neg="start", pin="both"
+    >>> before_start_wrap, after_start_wrap = mdt.nph.item_change_ix(
+    ...     a, axis=ax, pin="both", discard_neg="start", wrap=True
     ... )
-    >>> before_start
+    >>> before_start_wrap
+    (array([0, 0, 0, 1, 1, 1]), \
+array([0, 1, 1, 0, 0, 1]), \
+array([2, 0, 2, 0, 2, 2]))
+    >>> after_start_wrap
+    (array([0, 0, 0, 1, 1, 1]), \
+array([0, 0, 1, 0, 1, 1]), \
+array([0, 2, 2, 2, 0, 2]))
+    >>> before_end_typ_w, after_end_typ_w = mdt.nph.item_change_ix(
+    ...     a,
+    ...     axis=ax,
+    ...     pin="both",
+    ...     discard_neg="end",
+    ...     change_type="both",
+    ...     wrap=True,
+    ... )
+    >>> before_end_typ_w[0]  # Changes to higher values
+    (array([0, 0, 1, 1]), array([0, 1, 0, 1]), array([0, 2, 2, 0]))
+    >>> before_end_typ_w[1]  # Changes to lower values
+    (array([0, 1]), array([0, 1]), array([2, 2]))
+    >>> after_end_typ_w[0]  # Changes to higher values
+    (array([0, 0, 1, 1]), array([0, 1, 0, 1]), array([2, 0, 0, 2]))
+    >>> after_end_typ_w[1]  # Changes to lower values
+    (array([0, 1]), array([1, 0]), array([2, 2]))
+    >>> before_both_wrap, after_both_wrap = mdt.nph.item_change_ix(
+    ...     a, axis=ax, pin="both", discard_neg="both", wrap=True
+    ... )
+    >>> before_both_wrap
+    (array([0, 0, 1, 1]), array([0, 1, 0, 1]), array([2, 2, 2, 2]))
+    >>> after_both_wrap
+    (array([0, 0, 1, 1]), array([0, 1, 0, 1]), array([2, 2, 2, 2]))
+
+    >>> ax = 2
+    >>> before_both, after_both = mdt.nph.item_change_ix(
+    ...     a, axis=ax, pin="both", discard_neg="both"
+    ... )
+    >>> before_both
     (array([0, 1]), array([1, 0]), array([1, 1]))
-    >>> after_start
+    >>> after_both
     (array([0, 1]), array([1, 0]), array([2, 2]))
     >>> before_end_type, after_end_type = mdt.nph.item_change_ix(
     ...     a,
     ...     axis=ax,
-    ...     discard_neg="end",
     ...     pin="both",
+    ...     discard_neg="end",
     ...     change_type="both",
     ... )
     >>> before_end_type[0]  # Changes to higher values
@@ -4509,6 +4697,40 @@ array([0, 1, 0, 2, 0, 2, 0, 1]))
     (array([0, 1]), array([0, 1]), array([1, 1]))
     >>> after_end_type[1]
     (array([0, 1]), array([1, 0]), array([2, 2]))
+    >>> before_start_wrap, after_start_wrap = mdt.nph.item_change_ix(
+    ...     a, axis=ax, pin="both", discard_neg="start", wrap=True
+    ... )
+    >>> before_start_wrap
+    (array([0, 0, 0, 1, 1, 1]), \
+array([0, 1, 1, 0, 0, 1]), \
+array([2, 1, 2, 1, 2, 2]))
+    >>> after_start_wrap
+    (array([0, 0, 0, 1, 1, 1]), \
+array([0, 1, 1, 0, 0, 1]), \
+array([0, 0, 2, 0, 2, 0]))
+    >>> before_end_typ_w, after_end_typ_w = mdt.nph.item_change_ix(
+    ...     a,
+    ...     axis=ax,
+    ...     pin="both",
+    ...     discard_neg="end",
+    ...     change_type="both",
+    ...     wrap=True,
+    ... )
+    >>> before_end_typ_w[0]  # Changes to higher values
+    (array([0, 0, 1, 1]), array([0, 1, 0, 1]), array([0, 2, 2, 0]))
+    >>> before_end_typ_w[1]  # Changes to lower values
+    (array([0, 1]), array([1, 0]), array([1, 1]))
+    >>> after_end_typ_w[0]  # Changes to higher values
+    (array([0, 0, 1, 1]), array([0, 1, 0, 1]), array([1, 0, 0, 1]))
+    >>> after_end_typ_w[1]  # Changes to lower values
+    (array([0, 1]), array([1, 0]), array([2, 2]))
+    >>> before_both_wrap, after_both_wrap = mdt.nph.item_change_ix(
+    ...     a, axis=ax, pin="both", discard_neg="both", wrap=True
+    ... )
+    >>> before_both_wrap
+    (array([0, 0, 1, 1]), array([1, 1, 0, 0]), array([1, 2, 1, 2]))
+    >>> after_both_wrap
+    (array([0, 0, 1, 1]), array([1, 1, 0, 0]), array([0, 2, 0, 2]))
 
     Edge cases:
 
@@ -4519,12 +4741,12 @@ array([0, 1, 0, 2, 0, 2, 0, 1]))
     (array([], dtype=int64), array([], dtype=int64))
     >>> after
     (array([], dtype=int64), array([], dtype=int64))
-    >>> before, after = mdt.nph.item_change_ix(
+    >>> before_both, after_both = mdt.nph.item_change_ix(
     ...     a, axis=ax, pin="both", discard_neg="both"
     ... )
-    >>> before
+    >>> before_both
     (array([], dtype=int64), array([], dtype=int64))
-    >>> after
+    >>> after_both
     (array([], dtype=int64), array([], dtype=int64))
     >>> before_type, after_type = mdt.nph.item_change_ix(
     ...     a, axis=ax, pin="both", change_type="both"
@@ -4557,12 +4779,12 @@ array([0, 1, 0, 2, 0, 2, 0, 1]))
     (array([0]), array([0]))
     >>> after
     (array([0]), array([1]))
-    >>> before, after = mdt.nph.item_change_ix(
+    >>> before_both, after_both = mdt.nph.item_change_ix(
     ...     a, axis=ax, pin="both", discard_neg="both"
     ... )
-    >>> before
+    >>> before_both
     (array([0]), array([0]))
-    >>> after
+    >>> after_both
     (array([0]), array([1]))
     >>> before_type, after_type = mdt.nph.item_change_ix(
     ...     a, axis=ax, pin="both", change_type="both"
@@ -4595,12 +4817,12 @@ array([0, 1, 0, 2, 0, 2, 0, 1]))
     (array([], dtype=int64), array([], dtype=int64))
     >>> after
     (array([], dtype=int64), array([], dtype=int64))
-    >>> before, after = mdt.nph.item_change_ix(
+    >>> before_both, after_both = mdt.nph.item_change_ix(
     ...     a, axis=ax, pin="both", discard_neg="both"
     ... )
-    >>> before
+    >>> before_both
     (array([], dtype=int64), array([], dtype=int64))
-    >>> after
+    >>> after_both
     (array([], dtype=int64), array([], dtype=int64))
     >>> before_type, after_type = mdt.nph.item_change_ix(
     ...     a, axis=ax, pin="both", change_type="both"
@@ -4640,12 +4862,12 @@ array([0, 1, 0, 2, 0, 2, 0, 1]))
     (array([], dtype=int64), array([], dtype=int64))
     >>> after
     (array([], dtype=int64), array([], dtype=int64))
-    >>> before, after = mdt.nph.item_change_ix(
+    >>> before_both, after_both = mdt.nph.item_change_ix(
     ...     a, axis=ax, pin="both", discard_neg="both"
     ... )
-    >>> before
+    >>> before_both
     (array([], dtype=int64), array([], dtype=int64))
-    >>> after
+    >>> after_both
     (array([], dtype=int64), array([], dtype=int64))
     >>> before_type, after_type = mdt.nph.item_change_ix(
     ...     a, axis=ax, pin="both", change_type="both"
@@ -4827,17 +5049,8 @@ array([0, 1, 0, 2, 0, 2, 0, 1]))
     ...
     ValueError: The dimension of a must be greater than zero
     """
-    a = np.asarray(a)
-    if discard_neg not in (None, "start", "end", "both"):
-        return ValueError(
-            "`discard_neg` must be either None, 'start', 'end' or 'both' but"
-            " you gave '{}'".format(discard_neg)
-        )
-
     kwargs.setdefault("axis", -1)
-    pin = kwargs.setdefault("pin", "after")  # Given or default `pin`.
-    pin_intern = "both"  # Internally used `pin`.
-    kwargs["pin"] = pin_intern
+    pin = kwargs.setdefault("pin", "after")
     change_type = kwargs.setdefault("change_type", None)
     try:
         (i for i in change_type)
@@ -4845,78 +5058,16 @@ array([0, 1, 0, 2, 0, 2, 0, 1]))
     except TypeError:  # `change_type` is not iterable.
         ct_is_iterable = False
 
-    item_change_before, item_change_after = mdt.nph.locate_item_change(
-        a, **kwargs
-    )
-    if change_type == "both" or ct_is_iterable:
-        ix_before = tuple(np.nonzero(icb) for icb in item_change_before)
-        ix_after = tuple(np.nonzero(ica) for ica in item_change_after)
+    item_changes = mdt.nph.locate_item_change(a, **kwargs)
+    if pin == "both" and (change_type == "both" or ct_is_iterable):
+        return tuple(
+            tuple(np.nonzero(ic) for ic in ics) for ics in item_changes
+        )
+    elif pin == "both" or change_type == "both" or ct_is_iterable:
+        return tuple(np.nonzero(ic) for ic in item_changes)
     else:
-        ix_before = np.nonzero(item_change_before)
-        ix_after = np.nonzero(item_change_after)
-    del item_change_before, item_change_after
-
-    if discard_neg is not None:
-        if (
-            kwargs.pop("wrap", False)
-            or kwargs.pop("tfic", False)
-            or kwargs.pop("tlic", False)
-        ):
-            raise ValueError(
-                "`discard_neg` must not be used together with `wrap`, `tfic`"
-                " or `tlic`"
-            )
-        if change_type != "both" and not ct_is_iterable:
-            # Expand `ix_before` and `ix_after` to the same shape that
-            # they would have when `change_type` would be "both" or
-            # iterable.
-            ix_before = (ix_before,)
-            ix_after = (ix_after,)
-        if discard_neg in ("start", "both"):
-            # Get all item changes starting from a positive item.
-            valid_start = [None for ixb in ix_before]
-            for i, ixb in enumerate(ix_before):
-                valid_start[i] = a[ixb] >= 0
-            if discard_neg == "start":
-                valid = valid_start
-        if discard_neg in ("end", "both"):
-            # Get all item changes ending at a positive item.
-            valid_end = [None for ixa in ix_after]
-            for i, ixa in enumerate(ix_after):
-                valid_end[i] = a[ixa] >= 0
-            if discard_neg == "end":
-                valid = valid_end
-        if discard_neg == "both":
-            # Get all item changes starting from and ending at a
-            # positive item.
-            valid = [None for valid_st in valid_start]
-            for i, valid_st in enumerate(valid_start):
-                valid[i] = valid_st & valid_end[i]
-        # TODO: Allow to use `discard_neg` together with `wrap`.
-        # Therefore, `valid` must be changed accordingly at the
-        # trajectory boundaries.
-        ix_before = tuple(
-            tuple(ib[valid[i]] for ib in ixb)
-            for i, ixb in enumerate(ix_before)
-        )
-        ix_after = tuple(
-            tuple(ia[valid[i]] for ia in ixa) for i, ixa in enumerate(ix_after)
-        )
-        if change_type != "both" and not ct_is_iterable:
-            # Reduce `ix_before` and `ix_after` to their original shape.
-            ix_before = ix_before[0]
-            ix_after = ix_after[0]
-
-    if pin == "both":
-        return ix_before, ix_after
-    elif pin == "before":
-        return ix_before
-    elif pin == "after":
-        return ix_after
-    return ValueError(
-        "`pin` must be either 'after', 'before' or 'both' but you gave"
-        " '{}'".format(pin)
-    )
+        # `pin` != "both" and `change_type` != "both" and not iterable.
+        return np.nonzero(item_changes)
 
 
 def argmin_last(a, axis=None, out=None):

--- a/src/mdtools/numpy_helper_functions.py
+++ b/src/mdtools/numpy_helper_functions.py
@@ -2723,16 +2723,16 @@ array([], shape=(2, 0), dtype=bool))
     if tfic or tlic:
         if change_type is not None:
             raise ValueError(
-                "'tfic' and 'tlic' must not be used together with"
-                " 'change_type'"
+                "`tfic` and `tlic` must not be used together with"
+                " `change_type`"
             )
         if wrap:
             raise ValueError(
-                "'tfic' and 'tlic' must not be used together with 'wrap'"
+                "`tfic` and `tlic` must not be used together with `wrap`"
             )
         if mic:
             raise ValueError(
-                "'tfic' and 'tlic' must not be used together with 'mic'"
+                "`tfic` and `tlic` must not be used together with `mic`"
             )
 
     if mic:
@@ -2761,7 +2761,7 @@ array([], shape=(2, 0), dtype=bool))
         operators = (np.greater, np.less)
     elif isinstance(change_type, str):
         raise ValueError(
-            "'change_type' must be either None, 'higher', 'lower', 'both', a"
+            "`change_type` must be either None, 'higher', 'lower', 'both', a"
             " float or an iterable of floats, but you gave"
             " '{}'".format(change_type)
         )
@@ -2773,7 +2773,7 @@ array([], shape=(2, 0), dtype=bool))
             )
             if len(operators) == 0:
                 raise IndexError(
-                    "'change_type' ({}) must not be an empty"
+                    "`change_type` ({}) must not be an empty"
                     " iterable".format(change_type)
                 )
         except TypeError:  # change_type is not iterable
@@ -2864,8 +2864,8 @@ array([], shape=(2, 0), dtype=bool))
             return item_change_after
     else:
         return ValueError(
-            "'pin' must be either 'after', 'before' or 'both' but you gave"
-            " {}".format(pin)
+            "`pin` must be either 'after', 'before' or 'both' but you gave"
+            " '{}'".format(pin)
         )
     return item_change_before, item_change_after
 


### PR DESCRIPTION
# New functions to calculate transition rates from discrete trajectories

<!--
Thank you for your contribution!

Please fill out this pull request (PR) template and please take a look
at our developer's guide at
https://mdtools.readthedocs.io/en/latest/doc_pages/dev_guide/dev_guide.html
-->

<!--
Only for project maintainers, please do not remove!
Regex version for issue-labeler.
See https://github.com/github/issue-labeler

issue_labeler_regex_version=1
-->

## Type of change

* [x] Change of core package.
* [ ] Change of scripts.

<!-- Blank line -->

* [ ] Bug fix.
* [x] New feature.
* [ ] Code refactoring.
* [ ] Dependency update.
* [ ] Documentation update.
* [ ] Maintenance.
* [ ] Other: *Description*.

<!-- Blank line -->

* [x] Non-breaking (backward-compatible) change.
* [ ] Breaking (non-backward-compatible) change.

## Proposed changes

<!-- Give a concise summary of the most important changes. -->

* Create a new function `mdtools.dtrj.trans_rate` that calculates the transition rate for each compound averaged over all states.
* Create a new function `mdtools.dtrj.trans_rate_per_state` that calculates the transition rate for each state averaged over all compounds.
* Create a new function `mdtools.dtrj.get_ax` that returns the frame/compound axis for a discrete trajectory given its compound/frame axis.

<!-- Blank like -->

* Add a new argument `discard_neg` to the function `mdtools.numpy_helper_functions.locate_item_change` that allows the user to discard item changes starting from and/or ending in a negative item.
* Add a new argument `discard_neg` to the function `mdtools.numpy_helper_functions.item_change_ix` that allows the user to discard item changes starting from and/or ending in a negative item.
* Add a new argument `discard_neg` to the function `mdtools.dtrj.locate_trans` that allows the user to discard state transitions starting from and/or ending in a negative state.
* Add a new argument `discard_neg` to the function `mdtools.dtrj.trans_ix` that allows the user to discard state transitions starting from and/or ending in a negative state.

<!-- Blank like -->

* Add a new argument `axis` to the function `mdtools.dtrj.lifetimes` that allows the user to specify the axis along which to search for state transitions.
* Add a new argument `axis` to the function `mdtools.dtrj.lifetimes_per_state` that allows the user to specify the axis along which to search for state transitions.

## PR checklist

<!--
Please tick the check boxes accordingly.  Mark any check boxes that do
not apply to your PR as [~].
-->

* [x] I followed the guidelines in the [Developer's guide](https://mdtools.readthedocs.io/en/latest/doc_pages/dev_guide/dev_guide.html).
* [x] New/changed code is properly tested.
* [x] New/changed code is properly documented.
* [ ] The CI workflow is passing.
