### PR TITLE
Script `extract_renewal_events.py`: Fix AtomGroup Info in Output File

### DIFF
--- a/scripts/dynamics/extract_renewal_events.py
+++ b/scripts/dynamics/extract_renewal_events.py
@@ -966,7 +966,7 @@ if __name__ == "__main__":
         + "Allowed intermittency = {}\n".format(args.INTERMITTENCY)
         + "\n\n"
         + "Reference: '{}'\n".format(" ".join(args.REF))
-        + mdt.rti.ag_info_str(sel)
+        + mdt.rti.ag_info_str(ref)
         + "\n\n"
         + "Selection: '{}'\n".format(" ".join(args.SEL))
         + mdt.rti.ag_info_str(sel)


### PR DESCRIPTION
# Descriptive caption

<!--
Thank you for your contribution!

Please fill out this pull request (PR) template and please take a look
at our developer's guide at
https://mdtools.readthedocs.io/en/latest/doc_pages/dev_guide/dev_guide.html
-->

<!--
Only for project maintainers, please do not remove!
Regex version for issue-labeler.
See https://github.com/github/issue-labeler

issue_labeler_regex_version=1
-->

## Type of change

* [ ] Change of core package.
* [x] Change of scripts.

<!-- Blank line -->

* [x] Bug fix.
* [ ] New feature.
* [ ] Code refactoring.
* [ ] Dependency update.
* [ ] Documentation update.
* [ ] Maintenance.
* [ ] Other: *Description*.

<!-- Blank line -->

* [x] Non-breaking (backward-compatible) change.
* [ ] Breaking (non-backward-compatible) change.

## Proposed changes

<!-- Give a concise summary of the most important changes. -->

In the output file of the script `scripts/dynamics/extract_renewal_events.py` the information about the reference group was not about the reference but the selection group.  This is fixed by this PR.

## PR checklist

<!--
Please tick the check boxes accordingly.  Mark any check boxes that do
not apply to your PR as [~].
-->

* [x] I followed the guidelines in the [Developer's guide](https://mdtools.readthedocs.io/en/latest/doc_pages/dev_guide/dev_guide.html).
* [ ] New/changed code is properly tested.
* [~] New/changed code is properly documented.
* [ ] The CI workflow is passing.
