### PR TITLE
Add possibility to return the normalization factor of the back-jump probability

### DIFF
--- a/src/mdtools/dtrj.py
+++ b/src/mdtools/dtrj.py
@@ -5957,6 +5957,7 @@ def back_jump_prob_discrete(
     continuous=False,
     discard_neg=False,
     discard_neg_btw=False,
+    return_norm=False,
     verbose=False,
 ):
     r"""
@@ -5998,6 +5999,9 @@ def back_jump_prob_discrete(
     discard_neg_btw : bool, optional
         If ``True``, discard back jumps when the compound has visited a
         negative state between :math:`t_0` and :math:`t_0 + \Delta t`.
+    return_norm : bool, optional
+        If ``True``, return the normalization factors for all states and
+        all lag times.
     verbose : bool, optional
         If ``True`` print a progress bar.
 
@@ -6010,6 +6014,9 @@ def back_jump_prob_discrete(
         initial state j frames after a state transition has occurred,
         given that the compound was in state i of the second discrete
         trajectory at time :math:`t_0`.
+    norm : numpy.ndarray
+        Array of the same shape as `bj_prob` containing the
+        corresponding normalization factors.
 
     See Also
     --------
@@ -6308,7 +6315,6 @@ def back_jump_prob_discrete(
             " happened".format(bj_prob[:, 0])
         )
     bj_prob = bj_prob / norm
-    del norm
     if np.any(bj_prob < 0):
         raise ValueError(
             "At least one element of `bj_prob` is less than zero.  This should"
@@ -6324,4 +6330,7 @@ def back_jump_prob_discrete(
             "For at least one state is the sum of all back-jump probabilities"
             " greater than one.  This should not have happened"
         )
-    return bj_prob
+    if return_norm:
+        return bj_prob, norm
+    else:
+        return bj_prob

--- a/src/mdtools/dtrj.py
+++ b/src/mdtools/dtrj.py
@@ -5711,6 +5711,7 @@ def back_jump_prob(
     continuous=False,
     discard_neg=False,
     discard_neg_btw=False,
+    return_norm=False,
     verbose=False,
 ):
     r"""
@@ -5748,6 +5749,8 @@ def back_jump_prob(
     discard_neg_btw : bool, optional
         If ``True``, discard back jumps when the compound has visited a
         negative state between :math:`t_0` and :math:`t_0 + \Delta t`.
+    return_norm : bool, optional
+        If ``True``, return the normalization factors for all lag times.
     verbose : bool, optional
         If ``True`` print a progress bar.
 
@@ -5761,6 +5764,12 @@ def back_jump_prob(
         occurred.  Another interpretation could be that the k-th element
         of the array is the percentage of compounds that return back to
         there initial state k frames after a state transition has
+        occurred.
+    norm : numpy.ndarray
+        Array of the same shape as `bj_prob` containing the
+        corresponding normalization factors.  The k-th element of
+        ``bj_prob * norm`` is the number of compounds that return back
+        to there initial state k frames after a state transition has
         occurred.
 
     See Also
@@ -5916,7 +5925,6 @@ def back_jump_prob(
             )
 
     bj_prob = bj_prob / norm
-    del norm
     if bj_prob[0] != 0:
         raise ValueError(
             "`bj_prob[0]` = {} != 0.  This should not have"
@@ -5937,7 +5945,10 @@ def back_jump_prob(
             "The sum of all `bj_prob` is greater than one.  This should not"
             " have happened"
         )
-    return bj_prob
+    if return_norm:
+        return bj_prob, norm
+    else:
+        return bj_prob
 
 
 def back_jump_prob_discrete(


### PR DESCRIPTION
# Add possibility to return the normalization factor of the back-jump probability

<!--
Thank you for your contribution!

Please fill out this pull request (PR) template and please take a look
at our developer's guide at
https://mdtools.readthedocs.io/en/latest/doc_pages/dev_guide/dev_guide.html
-->

<!--
Only for project maintainers, please do not remove!
Regex version for issue-labeler.
See https://github.com/github/issue-labeler

issue_labeler_regex_version=1
-->

## Type of change

* [x] Change of core package.
* [ ] Change of scripts.

<!-- Blank line -->

* [ ] Bug fix.
* [x] New feature.
* [ ] Code refactoring.
* [ ] Dependency update.
* [ ] Documentation update.
* [ ] Maintenance.
* [ ] Other: *Description*.

<!-- Blank line -->

* [x] Non-breaking (backward-compatible) change.
* [ ] Breaking (non-backward-compatible) change.

## Proposed changes

<!-- Give a concise summary of the most important changes. -->

Functions `mdtools.dtrj.back_jump_prob` and `mdtools.dtrj.back_jump_prob_discrete`: Add a new argument `return_norm` that allows the user to return the normalization factor of the back-jump probability.

## PR checklist

<!--
Please tick the check boxes accordingly.  Mark any check boxes that do
not apply to your PR as [~].
-->

* [x] I followed the guidelines in the [Developer's guide](https://mdtools.readthedocs.io/en/latest/doc_pages/dev_guide/dev_guide.html).
* [ ] New/changed code is properly tested.
* [x] New/changed code is properly documented.
* [ ] The CI workflow is passing.
