### PR TITLE
Fix consistency checks of the Kaplan-Meier Estimator

### DIFF
--- a/src/mdtools/dtrj.py
+++ b/src/mdtools/dtrj.py
@@ -5231,9 +5231,10 @@ def kaplan_meier(*args, **kwargs):
     sf_var *= sf**2
 
     del n_leaves, n_risk
-    if sf[0] != 1:
+    if sf[0] != 1 and not np.isnan(sf[0]):
         raise ValueError(
-            "`sf[0]` = {} != 1.  This should not have happened".format(sf[0])
+            "`sf[0]` = {} != 1 or NaN.  This should not have"
+            " happened".format(sf[0])
         )
     if np.any(sf < 0):
         raise ValueError(
@@ -5683,7 +5684,7 @@ def kaplan_meier_discrete(*args, **kwargs):
     del n_leaves, n_risk
     if np.any(sf[:, 0][~np.isnan(sf[:, 0])] != 1):
         raise ValueError(
-            "`sf[:, 0]` = {} != 1.  This should not have"
+            "`sf[:, 0]` = {} != 1 or NaN.  This should not have"
             " happened".format(sf[:, 0])
         )
     if np.any(sf < 0):

--- a/src/mdtools/dtrj.py
+++ b/src/mdtools/dtrj.py
@@ -4651,9 +4651,9 @@ def leave_prob(*args, **kwargs):
     prob = np.full_like(n_leaves, np.nan, dtype=np.float64)
     prob = np.divide(n_leaves, n_risk, where=(n_risk != 0), out=prob)
     del n_leaves, n_risk
-    if prob[0] != 0:
+    if prob[0] != 0 and not np.isnan(prob[0]):
         raise ValueError(
-            "`prob[0]` = {} != 0.  This should not have"
+            "`prob[0]` = {} != 0 or NaN.  This should not have"
             " happened".format(prob[0])
         )
     if np.any(prob < 0):
@@ -4924,7 +4924,7 @@ def leave_prob_discrete(*args, **kwargs):
     del n_leaves, n_risk
     if np.any(prob[:, 0][~np.isnan(prob[:, 0])] != 0):
         raise ValueError(
-            "`prob[:, 0]` = {} != 0.  This should not have"
+            "`prob[:, 0]` = {} != 0 or NaN.  This should not have"
             " happened".format(prob[:, 0])
         )
     if np.any(prob < 0):


### PR DESCRIPTION
# Fix consistency checks of the Kaplan-Meier Estimator

<!--
Thank you for your contribution!

Please fill out this pull request (PR) template and please take a look
at our developer's guide at
https://mdtools.readthedocs.io/en/latest/doc_pages/dev_guide/dev_guide.html
-->

<!--
Only for project maintainers, please do not remove!
Regex version for issue-labeler.
See https://github.com/github/issue-labeler

issue_labeler_regex_version=1
-->

## Type of change

* [x] Change of core package.
* [ ] Change of scripts.

<!-- Blank line -->

* [x] Bug fix.
* [ ] New feature.
* [ ] Code refactoring.
* [ ] Dependency update.
* [ ] Documentation update.
* [ ] Maintenance.
* [ ] Other: *Description*.

<!-- Blank line -->

* [x] Non-breaking (backward-compatible) change.
* [ ] Breaking (non-backward-compatible) change.

## Proposed changes

<!-- Give a concise summary of the most important changes. -->

* Function `mdtools.dtrj.kaplan_meier`: The first element of the returned survival-function array can not only be zero but also NaN.
* Function `mdtools.dtrj.leave_prob`: The first element of the returned leave-probability array can not only be zero but also NaN.

## PR checklist

<!--
Please tick the check boxes accordingly.  Mark any check boxes that do
not apply to your PR as [~].
-->

* [x] I followed the guidelines in the [Developer's guide](https://mdtools.readthedocs.io/en/latest/doc_pages/dev_guide/dev_guide.html).
* [ ] New/changed code is properly tested.
* [~] New/changed code is properly documented.
* [ ] The CI workflow is passing.
