### PR TITLE
Hexagonal binning: Don't Print Information About Surface Moves

### DIFF
--- a/scripts/discretization/discrete_hex.py
+++ b/scripts/discretization/discrete_hex.py
@@ -411,18 +411,18 @@ if __name__ == '__main__':
             timer_frame = datetime.now()
 
         if not np.allclose(surf.positions, surf_pos):
-            print(flush=True)
-            print("  Note: The surface has moved in", flush=True)
-            print("  Frame {:12d}".format(ts.frame), flush=True)
-            print("  Step: {:>12}    Time: {:>12} (ps)"
-                  .format(ts.data['step'], ts.data['time']),
-                  flush=True)
+            # print(flush=True)
+            # print("  Note: The surface has moved in", flush=True)
+            # print("  Frame {:12d}".format(ts.frame), flush=True)
+            # print("  Step: {:>12}    Time: {:>12} (ps)"
+            #       .format(ts.data['step'], ts.data['time']),
+            #       flush=True)
             n_surf_moves += 1
             ix_sort1 = np.lexsort(surf.positions[:, ::-1].T)
             ix_sort2 = np.lexsort(surf_pos[:, ::-1].T)
             if not np.allclose(surf.positions[ix_sort1],
                                surf_pos[ix_sort2]):
-                print("  This was a dangerous move!", flush=True)
+                # print("  This was a dangerous move!", flush=True)
                 n_surf_moves_dangerous += 1
             del ix_sort1, ix_sort2
             lattice = hex_verts2faces(verts=surf.positions,

--- a/scripts/structure/axial_hex_distribution_1nn.py
+++ b/scripts/structure/axial_hex_distribution_1nn.py
@@ -713,12 +713,12 @@ if __name__ == '__main__':
                            surf_pos_prev,
                            rtol=0,
                            atol=args.TOL):
-            print(flush=True)
-            print("  Note: The surface has moved in", flush=True)
-            print("  Frame {:12d}".format(ts.frame), flush=True)
-            print("  Step: {:>12}    Time: {:>12} (ps)"
-                  .format(ts.data['step'], ts.data['time']),
-                  flush=True)
+            # print(flush=True)
+            # print("  Note: The surface has moved in", flush=True)
+            # print("  Frame {:12d}".format(ts.frame), flush=True)
+            # print("  Step: {:>12}    Time: {:>12} (ps)"
+            #       .format(ts.data['step'], ts.data['time']),
+            #       flush=True)
             n_surf_moves += 1
             ix_sort1 = np.lexsort(surf.positions.T)
             ix_sort2 = np.lexsort(surf_pos_prev.T)
@@ -726,9 +726,9 @@ if __name__ == '__main__':
                                surf_pos_prev[ix_sort2],
                                rtol=0,
                                atol=args.TOL):
-                print("  This was a dangerous move!", flush=True)
+                # print("  This was a dangerous move!", flush=True)
                 n_surf_moves_dangerous += 1
-            print(flush=True)
+            # print(flush=True)
             del ix_sort1, ix_sort2
             hex_face_col = get_1st_hex_face_col(verts=surf.positions,
                                                 r0=args.R0,

--- a/scripts/structure/axial_hex_distribution_2nn.py
+++ b/scripts/structure/axial_hex_distribution_2nn.py
@@ -511,12 +511,12 @@ if __name__ == '__main__':
                            surf_pos_prev,
                            rtol=0,
                            atol=args.TOL):
-            print(flush=True)
-            print("  Note: The surface has moved in", flush=True)
-            print("  Frame {:12d}".format(ts.frame), flush=True)
-            print("  Step: {:>12}    Time: {:>12} (ps)"
-                  .format(ts.data['step'], ts.data['time']),
-                  flush=True)
+            # print(flush=True)
+            # print("  Note: The surface has moved in", flush=True)
+            # print("  Frame {:12d}".format(ts.frame), flush=True)
+            # print("  Step: {:>12}    Time: {:>12} (ps)"
+            #       .format(ts.data['step'], ts.data['time']),
+            #       flush=True)
             n_surf_moves += 1
             ix_sort1 = np.lexsort(surf.positions.T)
             ix_sort2 = np.lexsort(surf_pos_prev.T)
@@ -524,9 +524,9 @@ if __name__ == '__main__':
                                surf_pos_prev[ix_sort2],
                                rtol=0,
                                atol=args.TOL):
-                print("  This was a dangerous move!", flush=True)
+                # print("  This was a dangerous move!", flush=True)
                 n_surf_moves_dangerous += 1
-            print(flush=True)
+            # print(flush=True)
             del ix_sort1, ix_sort2
             hex_face_cols = get_1st_hex_face_cols(verts=surf.positions,
                                                   r0=args.R0,


### PR DESCRIPTION
# Hexagonal binning: Don't Print Information About Surface Moves

<!--
Thank you for your contribution!

Please fill out this pull request (PR) template and please take a look
at our developer's guide at
https://mdtools.readthedocs.io/en/latest/doc_pages/dev_guide/dev_guide.html
-->

<!--
Only for project maintainers, please do not remove!
Regex version for issue-labeler.
See https://github.com/github/issue-labeler

issue_labeler_regex_version=1
-->

## Type of change

* [ ] Change of core package.
* [x] Change of scripts.

<!-- Blank line -->

* [ ] Bug fix.
* [ ] New feature.
* [x] Code refactoring.
* [ ] Dependency update.
* [ ] Documentation update.
* [ ] Maintenance.
* [ ] Other: *Description*.

<!-- Blank line -->

* [x] Non-breaking (backward-compatible) change.
* [ ] Breaking (non-backward-compatible) change.

## Proposed changes

<!-- Give a concise summary of the most important changes. -->

* Scripts `discrete_hex.py`, `axial_hex_distribution_1nn.py`and `axial_hex_distribution_2nn.py`: Don't print information about surface moves every time step.

## PR checklist

<!--
Please tick the check boxes accordingly.  Mark any check boxes that do
not apply to your PR as [~].
-->

* [x] I followed the guidelines in the [Developer's guide](https://mdtools.readthedocs.io/en/latest/doc_pages/dev_guide/dev_guide.html).
* [ ] New/changed code is properly tested.
* [~] New/changed code is properly documented.
* [ ] The CI workflow is passing.
